### PR TITLE
Feature/add iri method

### DIFF
--- a/lib/jekyll/drops/rdf_literal.rb
+++ b/lib/jekyll/drops/rdf_literal.rb
@@ -34,7 +34,7 @@ module Jekyll
       ##
       # Return a user-facing string representing this RdfLiteral
       #
-      def name
+      def literal
         term.to_s
       end
 

--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -98,10 +98,7 @@ module Jekyll #:nodoc:
         end
       end
 
-      ##
-      # Returns the URI of this resource
-      #
-      def name
+      def iri
         term.to_s
       end
 

--- a/lib/jekyll/drops/rdf_term.rb
+++ b/lib/jekyll/drops/rdf_term.rb
@@ -53,10 +53,13 @@ module Jekyll
       end
 
       ##
-      # Convert this RdfTerm into a human-readable string
+      # Convert this RdfTerm into a string
+      # This should be:
+      # - for resoruces: the IRI
+      # - for literals: the literal representation e.g. "Hallo"@de or "123"^^<http://www.w3.org/2001/XMLSchema#integer>
       #
       def to_s
-        name
+        term.to_s
       end
 
       ##

--- a/lib/jekyll/filters/rdf_property.rb
+++ b/lib/jekyll/filters/rdf_property.rb
@@ -57,10 +57,10 @@ module Jekyll
         return unless !result.empty?
         if(list)
           return result.map{|p|
-            p.object.name.to_s
+            p.object.to_s
           }
         else
-          return (result.first.object.name).to_s
+          return (result.first.object).to_s
         end
       end
     end

--- a/lib/jekyll/rdf_page_data.rb
+++ b/lib/jekyll/rdf_page_data.rb
@@ -46,7 +46,7 @@ module Jekyll
 
       template = mapper.map(resource)
       self.read_yaml(File.join(base, '_layouts'), template)
-      self.data['title'] = resource.name
+      self.data['title'] = resource.iri
       self.data['rdf'] = resource
       if(!resource.subResources.nil?)
         self.data['sub_rdf'] = resource.subResources.values
@@ -64,7 +64,7 @@ module Jekyll
             [arr[0][7..-1].strip, arr[1].strip[1..-2]]
           }.flatten)]
         rescue Errno::ENOENT => ex
-          Jekyll.logger.error("context: #{resource.name}  template: #{template}  file not found: #{File.join(base, 'rdf-data', self.data["rdf_prefix_path"])}")
+          Jekyll.logger.error("context: #{resource}  template: #{template}  file not found: #{File.join(base, 'rdf-data', self.data["rdf_prefix_path"])}")
         end
       end
       resource.page = self

--- a/test/source/_includes/simPerson.html
+++ b/test/source/_includes/simPerson.html
@@ -1,7 +1,8 @@
 <div>
   {% assign person = include.person %}
-  Name: {{person.name}}
-  Age: {{person | rdf_property: 'foaf:age'}}
+  IRI: {{person}} <br/>
+  Name: {{person | rdf_property: 'foaf:name'}} <br/>
+  Age: {{person | rdf_property: 'foaf:age'}} <br/>
   {% assign jobs = person | rdf_property: '<http://xmlns.com/foaf/0.1/job>', 'cfg', true %}
   Job:  {% for job in jobs %}
             {{job}}

--- a/test/source/_layouts/abraham.html
+++ b/test/source/_layouts/abraham.html
@@ -20,15 +20,15 @@ layout: abraham_outer_layout
   </table>
 
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as subject:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as subject:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_subject %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as predicate:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as predicate:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_predicate %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as object:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as object:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_object %}
   </p>
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>

--- a/test/source/_layouts/default.html
+++ b/test/source/_layouts/default.html
@@ -15,9 +15,9 @@
         <h3>List of resources:</h3>
         <ul>
           {% for my_page in site.pages %}
-            {% if my_page.rdf.name %}
+            {% if my_page.rdf.iri %}
               <li>
-                <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.rdf.name }}</a>
+                <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.rdf | rdf_property: 'foaf:name' }} ({{ my_page.rdf.iri }})</a>
               </li>
             {% endif %}
           {% endfor %}

--- a/test/source/_layouts/homer.html
+++ b/test/source/_layouts/homer.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="home">
 
-  <h1 class="page-heading"><b>Person: {{ page.rdf.name }}</b></h1>
+  <h1 class="page-heading"><b>Person: {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }})</b></h1>
 
   <table border="1">
     <tbody>
@@ -61,15 +61,15 @@ layout: default
   </table>
 
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as subject:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as subject:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_subject %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as predicate:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as predicate:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_predicate %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as object:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as object:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_object %}
   </p>
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>

--- a/test/source/_layouts/person.html
+++ b/test/source/_layouts/person.html
@@ -33,15 +33,15 @@ layout: default_stripped
   </table>
 
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as subject:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as subject:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_subject %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as predicate:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as predicate:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_predicate %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as object:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as object:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_object %}
   </p>
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>

--- a/test/source/_layouts/rdf_index.html
+++ b/test/source/_layouts/rdf_index.html
@@ -4,18 +4,18 @@ layout: default_stripped
 
 <div class="home">
 
-  <h1 class="page-heading"><b>{{ page.rdf.name }}</b></h1>
+  <h1 class="page-heading"><b>{{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }})</b></h1>
 
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as subject:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as subject:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_subject %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as predicate:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as predicate:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_predicate %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as object:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as object:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_object %}
   </p>
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>

--- a/test/source/_layouts/simpsonPerson.html
+++ b/test/source/_layouts/simpsonPerson.html
@@ -33,15 +33,15 @@ layout: default_stripped
   </table>
 
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as subject:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as subject:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_subject %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as predicate:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as predicate:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_predicate %}
   </p>
   <p>
-    <h3>Statements in which {{ page.rdf.name }} occurs as object:</h3>
+    <h3>Statements in which {{ page.rdf | rdf_property: 'foaf:name' }} ({{ page.rdf.iri }}) occurs as object:</h3>
     {% include statements_table.html collection=page.rdf.statements_as_object %}
   </p>
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>

--- a/test/test_jekyll-rdf.rb
+++ b/test/test_jekyll-rdf.rb
@@ -41,7 +41,7 @@ class TestJekyllRdf < Test::Unit::TestCase
   include Jekyll::RdfProperty
   include Jekyll::RdfSparqlQuery
   context "Generate a rdf_resource Homer that" do
-    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.iri == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'} #needs to be adjusted to http://www.ifi.uio.no/INF3580/simpsons#Homer when branch gets merged with Fix_Wrong_Naming_Issue
+    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.iri == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'}
 
     should "contain correct age of Homer Simpson" do
       plain_statements =  homer_resource.statements.map{|statement| [statement.subject.to_s, statement.predicate.to_s, statement.object.to_s]}
@@ -58,7 +58,7 @@ class TestJekyllRdf < Test::Unit::TestCase
   end
 
   context "rdf_sparql_query" do
-    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.iri == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'} #needs to be adjusted to http://www.ifi.uio.no/INF3580/simpsons#Homer when branch gets merged with Fix_Wrong_Naming_Issue
+    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.iri == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'}
 
     should "create a result " do
       query = "SELECT ?s WHERE{ ?s fam:hasFather ?resourceUri }"

--- a/test/test_jekyll-rdf.rb
+++ b/test/test_jekyll-rdf.rb
@@ -41,7 +41,7 @@ class TestJekyllRdf < Test::Unit::TestCase
   include Jekyll::RdfProperty
   include Jekyll::RdfSparqlQuery
   context "Generate a rdf_resource Homer that" do
-    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.name == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'} #needs to be adjusted to http://www.ifi.uio.no/INF3580/simpsons#Homer when branch gets merged with Fix_Wrong_Naming_Issue
+    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.iri == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'} #needs to be adjusted to http://www.ifi.uio.no/INF3580/simpsons#Homer when branch gets merged with Fix_Wrong_Naming_Issue
 
     should "contain correct age of Homer Simpson" do
       plain_statements =  homer_resource.statements.map{|statement| [statement.subject.to_s, statement.predicate.to_s, statement.object.to_s]}
@@ -53,12 +53,12 @@ class TestJekyllRdf < Test::Unit::TestCase
     end
 
     should "have a job listed with the language tag 'en'" do
-      assert rdf_property(homer_resource, "<http://xmlns.com/foaf/0.1/job>", "en", false) == "unknown"
+      assert_equal("unknown", rdf_property(homer_resource, "<http://xmlns.com/foaf/0.1/job>", "en", false))
     end
   end
 
   context "rdf_sparql_query" do
-    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.name == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'} #needs to be adjusted to http://www.ifi.uio.no/INF3580/simpsons#Homer when branch gets merged with Fix_Wrong_Naming_Issue
+    homer_resource = simpson_page.data['sub_rdf'].find{|res| res.iri == 'http://www.ifi.uio.no/INF3580/simpsons#Homer'} #needs to be adjusted to http://www.ifi.uio.no/INF3580/simpsons#Homer when branch gets merged with Fix_Wrong_Naming_Issue
 
     should "create a result " do
       query = "SELECT ?s WHERE{ ?s fam:hasFather ?resourceUri }"

--- a/test/test_rdf_page_data.rb
+++ b/test/test_rdf_page_data.rb
@@ -28,11 +28,11 @@ class TestRdfPageData < Test::Unit::TestCase
     end
 
     should "have correct job" do
-      assert_equal page.data['rdf'].statements[4].object.name, "unknown"
+      assert_equal page.data['rdf'].statements[4].object.literal, "unknown"
     end
 
     should "have correct translated job" do
-      assert_equal page.data['rdf'].statements[5].object.name, "unbekannt"
+      assert_equal page.data['rdf'].statements[5].object.literal, "unbekannt"
     end
 
     should "have 16 rdf statements" do


### PR DESCRIPTION
Fix #6.
This provides a `.iri` method on resources and `.literal` method on literals.
The `.name` method on terms is removed and similar behavior to cover all terms is provided by the `.to_s` method.
Please check if this looks good for you.