### PR TITLE
Add support for rdfs:Container and its subclasses

### DIFF
--- a/lib/jekyll/filters/rdf_container.rb
+++ b/lib/jekyll/filters/rdf_container.rb
@@ -42,8 +42,8 @@ module Jekyll
     end
 
     def valid_container?(input, sparql_client, type = nil)
-      ask_query1 = "ASK WHERE {VALUES ?o {<http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt>} #{input.term.to_ntriples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}"
-      ask_query2 = "ASK WHERE {#{input.term.to_ntriples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o. ?o <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Container>}"
+      ask_query1 = "ASK WHERE {VALUES ?o {<http://www.w3.org/2000/01/rdf-schema#Container> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt>} #{input.term.to_ntriples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}"
+      ask_query2 = "ASK WHERE {#{input.term.to_ntriples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o. ?o <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.w3.org/2000/01/rdf-schema#Container>}"
       return (sparql_client.query(ask_query1).true?) || (sparql_client.query(ask_query2).true?)
     end
   end

--- a/test/source/rdf-data/simpsons.ttl
+++ b/test/source/rdf-data/simpsons.ttl
@@ -136,12 +136,31 @@ simc:c3 rdf:first sim:Maggie.
 simc:c3 rdf:rest simc:c4.
 simc:c4 rdf:first sim:Lisa.
 simc:c4 rdf:rest rdf:nil.
-simcon:Container a rdf:Seq.
+
+simcon:Seq a rdf:Seq.
+simcon:Seq rdf:_1 sim:Homer.
+simcon:Seq rdf:_2 sim:Marge.
+simcon:Seq rdf:_3 sim:Bart.
+simcon:Seq rdf:_4 sim:Lisa.
+simcon:Seq rdf:_5 sim:Maggie.
+
+simcon:Container a rdfs:Container .
 simcon:Container rdf:_1 sim:Homer.
 simcon:Container rdf:_2 sim:Marge.
 simcon:Container rdf:_3 sim:Bart.
 simcon:Container rdf:_4 sim:Lisa.
 simcon:Container rdf:_5 sim:Maggie.
+
+simcon:ContainerClass rdfs:subClassOf simcon:ContainmentClass .
+simcon:ContainmentClass rdfs:subClassOf rdfs:Container .
+
+simcon:CustomContainer a simcon:ContainerClass .
+simcon:CustomContainer rdf:_1 sim:Homer.
+simcon:CustomContainer rdf:_2 sim:Marge.
+simcon:CustomContainer rdf:_3 sim:Bart.
+simcon:CustomContainer rdf:_4 sim:Lisa.
+simcon:CustomContainer rdf:_5 sim:Maggie.
+
 dtp16:SparqlClient a plh:object.
 plh:object1 plh:predicate2 plh:object2.
 plh:subject1 plh:predicate1 plh:object1.

--- a/test/test_rdf_filters.rb
+++ b/test/test_rdf_filters.rb
@@ -167,11 +167,31 @@ class TestRdfFilter < Test::Unit::TestCase
   context "Filter rdf_container from Jekyll::RdfContainer" do
     setup do
       prefixes = {"rdf" => "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs" => "http://www.w3.org/2000/01/rdf-schema#", "foaf" => "http://xmlns.com/foaf/0.1/", "fam" => "http://www.ifi.uio.no/INF3580/family#", "simcon" => "http://www.ifi.uio.no/INF3580/simpson-container#"}
-      @testResource = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#Container", prefixes)
+      @testSeq = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#Seq", prefixes)
+      @testContainer = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#Container", prefixes)
+      @testCustomContainer = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#CustomContainer", prefixes)
     end
 
-    should "return a set of resources stashed in the passed collection" do
-      answer = rdf_container(@testResource)
+    should "return a set of resources stashed in the passed sequence container" do
+      answer = rdf_container(@testSeq)
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Homer"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Homer")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Marge"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Marge")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Bart"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Bart")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
+    end
+
+    should "return a set of resources stashed in the passed container" do
+      answer = rdf_container(@testContainer)
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Homer"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Homer")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Marge"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Marge")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Bart"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Bart")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
+    end
+
+    should "return a set of resources stashed in the passed custom collection" do
+      answer = rdf_container(@testCustomContainer)
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Homer"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Homer")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Marge"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Marge")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Bart"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Bart")
@@ -180,7 +200,7 @@ class TestRdfFilter < Test::Unit::TestCase
     end
 
     should "use a container validator that recognizes container" do
-      assert valid_container?(@testResource, @testResource.sparql), "validContainer? returned false"
+      assert valid_container?(@testSeq, @testSeq.sparql), "validContainer? returned false"
     end
 
     should "use a container validator that recognizes non container" do


### PR DESCRIPTION
- directly support containers of type rdfs:Container
- support any subclass of rdfs:Container
- add tests accordingly

Fix #87