### PR TITLE
non-existent classes do not interupt jekyll-rdf anymore

### DIFF
--- a/lib/jekyll/rdf_class_extraction.rb
+++ b/lib/jekyll/rdf_class_extraction.rb
@@ -25,10 +25,22 @@ module Jekyll
 
       def assign_class_templates(classes_to_templates)
         if(classes_to_templates.is_a?(Hash))
+          @classResources.default = StopObject.new
           classes_to_templates.each{|key, value|
             @classResources[key].propagate_template(value,0)
             @classResources[key].traverse_hierarchy_value(0);
           }
+          @classResources.default = nil
+        end
+      end
+
+      class StopObject #unfortunately next does not work in this setup, it avoids to have "if" in every iteration
+        def propagate_template(template, lock)
+          return
+        end
+
+        def traverse_hierarchy_value(predecessorHierarchyValue)
+          return
         end
       end
   end

--- a/test/source/_config.yml
+++ b/test/source/_config.yml
@@ -36,6 +36,7 @@ jekyll_rdf:
     "http://pcai042.informatik.uni-leipzig.de/~dtp16/#ThirdSpecialPerson" : "person.html"
     "http://pcai042.informatik.uni-leipzig.de/~dtp16/#SpecialPerson" : "person.html"
     "http://pcai042.informatik.uni-leipzig.de/~dtp16/#SimpsonPerson" : "simpsonPerson.html"
+    "http://this.class/does/not/exist" : "person.html"
   instance_template_mappings:
     "http://www.ifi.uio.no/INF3580/main" : "main.html"
     "http://www.ifi.uio.no/INF3580/simpsons#Abraham" : "abraham.html"


### PR DESCRIPTION
Fix #97 