### PR TITLE
Updated README.md to Jekyll serving 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,39 +46,27 @@ First, you need a jekyll page. In order to create one, just do:
 jekyll new my_page
 cd my_page
 ```
-Add `jekyll-rdf` to your `_config.yml`:
-```yaml
-gems: [jekyll-rdf]
-```
-Specify path to your RDF-File in `_config.yml`:
-```yaml
-jekyll_rdf:
-  path: "simpsons.ttl"
-```
 
-Running `jekyll build` will render the RDF resources to `_site/rdfsites/…` for including resource pages into the root of the site you have to specify the `url:` and `baseurl:` parameters of the jekyll configuration accordingly.
+Further there are some parameters required in your `_config.yml` for `jekyll-rdf`. I.e. the `url` and `baseurl` parameters are used for including the resource pages into the root of the site, the plug-in has to be configured, and the path to the RDF file has to be present.
 
-In the example of the simpsons model it could be:
 ```yaml
-baseurl: "/INF3580"
 url: "http://www.ifi.uio.no"
-```
-### Deployment in Jekyll 3.3.0
-To deploy your custom jekyll-rdf content, you have to build your website:
-```
-  jekyll build
-```
-Do not just use
-```
-  jekyll serve
-```
-Since version 3.3.0, Jekyll overwrites its variable site.url with your host and port reference,
-breaking some of jekyll-rdfs linking features. Instead, use
-```
-  jekyll serve --skip-initial-build
+baseurl: "/INF3580"
+
+plugins:
+    - jekyll-rdf
+
+jekyll_rdf:
+    path: "simpsons.ttl"
 ```
 
-Another possibility is to set `JEKYLL_ENV=production`. It causes `jekyll serve` to work properly.
+Running `jekyll build` will render the RDF resources to the `_site/…` directory.
+RDF resources whose IRIs don't start with the configured jekyll `url` and `baseurl` are rendered to the `_site/rdfsites/…` subdirectory.
+
+*Note:* Since Jekyll 3.3.0 there is a special behavior of the `jekyll serve` command in a development environment.
+Jekyll overwrites the `site.url` variable with your host and port reference, as [described in the Jekyll documentation](https://jekyllrb.com/docs/variables/#site-variables).
+The behavior breaks the jekyll-rdf resource creation.
+If you want to use `jekyll serve` you have to run `jekyll serve --skip-initial-build` or set `JEKYLL_ENV=production`.
 
 ## Make use of RDF data
 ### Templates

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ In the example of the simpsons model it could be:
 baseurl: "/INF3580"
 url: "http://www.ifi.uio.no"
 ```
+### Deployment in Jekyll 3.3.0
+To deploy your custom jekyll-rdf content, you have to build your website:
+```
+  jekyll build
+```
+Do not just use
+```
+  jekyll serve
+```
+Since version 3.3.0, Jekyll overwrites its variable site.url with your host and port reference,
+breaking some of jekyll-rdfs linking features. Instead, use
+```
+  jekyll serve --skip-initial-build
+```
+
+Another possibility is to set `JEKYLL_ENV=production`. It causes `jekyll serve` to work properly.
 
 ## Make use of RDF data
 ### Templates


### PR DESCRIPTION
Since 3.3 Jekyll overwrites site.url when using 'jekyll serve'. Described in https://github.com/white-gecko/jekyll-rdf/issues/102