### PR TITLE
API change and code cleaning

### DIFF
--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -49,8 +49,8 @@ module Jekyll #:nodoc:
       ##
       #
       #
-      def initialize(term, sparql, site = nil, page = nil)
-        super(term, sparql)
+      def initialize(term, site = nil, page = nil)
+        super(term)
         if(site.is_a?(Jekyll::Site))
           @site = site
         end
@@ -161,19 +161,19 @@ module Jekyll #:nodoc:
         case role
           when :subject
             query = "SELECT ?p ?o ?dt ?lit ?lang WHERE{ #{input_uri} ?p ?o BIND(datatype(?o) AS ?dt) BIND(isLiteral(?o) AS ?lit) BIND(lang(?o) AS ?lang)}"
-            sparql.query(query).map do |solution|
+            Jekyll::RdfHelper::sparql.query(query).map do |solution|
               check = check_solution(solution)
               create_statement(term.to_s, solution.p, solution.o, solution.lit, check[:lang], check[:data_type])
             end
           when :predicate
             query = "SELECT ?s ?o ?dt ?lit ?lang WHERE{ ?s #{input_uri} ?o BIND(datatype(?o) AS ?dt) BIND(isLiteral(?o) AS ?lit) BIND(lang(?o) AS ?lang)}"
-            sparql.query(query).map do |solution|
+            Jekyll::RdfHelper::sparql.query(query).map do |solution|
               check = check_solution(solution)
               create_statement(solution.s, term.to_s, solution.o, solution.lit, check[:lang], check[:data_type])
             end
           when :object
             query = "SELECT ?s ?p WHERE{ ?s ?p #{input_uri}}"
-            sparql.query(query).map do |solution|
+            Jekyll::RdfHelper::sparql.query(query).map do |solution|
               create_statement( solution.s, solution.p, term.to_s)
             end
           else
@@ -209,7 +209,7 @@ module Jekyll #:nodoc:
         else
           object = RDF::URI(object_string)
         end
-        return RdfStatement.new(RDF::Statement( subject, predicate, object), @sparql, @site)
+        return RdfStatement.new(RDF::Statement( subject, predicate, object), @site)
       end
 
       private

--- a/lib/jekyll/drops/rdf_resource_class.rb
+++ b/lib/jekyll/drops/rdf_resource_class.rb
@@ -38,13 +38,15 @@ module Jekyll #:nodoc:
       attr_accessor :alternativeTemplates
       attr_accessor :subClasses
       attr_accessor :subClassHierarchyValue
+      attr_reader :sparql
 
       def initialize(term, sparql)
-        super(term, sparql)
+        super(term)
         @subClasses = []
         @lock = -1
         @subClassHierarchyValue = 0
         @alternativeTemplates = []
+        @sparql = sparql
       end
 
       def multiple_templates?
@@ -52,12 +54,7 @@ module Jekyll #:nodoc:
       end
 
       def find_direct_subclasses
-        if(!@term.to_s[0..1].eql? "_:")
-          term_uri = "<#{@term.to_s}>"
-        else
-          term_uri = @term.to_s
-        end
-        query = "SELECT ?s WHERE{ ?s <http://www.w3.org/2000/01/rdf-schema#subClassOf> #{term_uri}}"
+        query = "SELECT ?s WHERE{ ?s <http://www.w3.org/2000/01/rdf-schema#subClassOf> #{@term.to_ntriples}}"
         selection = @sparql.query(query).map{ |solution| solution.s.to_s}
         return selection
       end

--- a/lib/jekyll/drops/rdf_statement.rb
+++ b/lib/jekyll/drops/rdf_statement.rb
@@ -52,10 +52,10 @@ module Jekyll
       # * +statement+ - The statement to be represented
       # * +sparql+ - The SPARQL::Client which contains the +statement+
       # * +site+ - The Jekyll::Site to be enriched
-      def initialize(statement, sparql, site)
-        @subject ||= Jekyll::Drops::RdfTerm.build_term_drop(statement.subject, sparql, site)
-        @predicate ||= Jekyll::Drops::RdfTerm.build_term_drop(statement.predicate, sparql, site)
-        @object ||= Jekyll::Drops::RdfTerm.build_term_drop(statement.object, sparql, site)
+      def initialize(statement, site)
+        @subject ||= Jekyll::Drops::RdfTerm.build_term_drop(statement.subject, site)
+        @predicate ||= Jekyll::Drops::RdfTerm.build_term_drop(statement.predicate, site)
+        @object ||= Jekyll::Drops::RdfTerm.build_term_drop(statement.object, site)
       end
 
       def inspect

--- a/lib/jekyll/drops/rdf_term.rb
+++ b/lib/jekyll/drops/rdf_term.rb
@@ -37,30 +37,23 @@ module Jekyll
       attr_reader :term
 
       ##
-      # The SPARQL::Client which contains the represented +term+
-      #
-      attr_reader :sparql
-
-      ##
       # Create a new Jekyll::Drops::RdfTerm
       #
       # * +term+ - The term to be represented
-      # * +sparql+ - The SPARQL::Client which contains the represented +term+
       #
-      def initialize(term, sparql)
+      def initialize(term)
         @term  ||= term
-        @sparql ||= sparql
       end
 
       ##
-      # Funktion stub with no funktionality. Its purpose is to keep RdfResource compatible.
+      # Function stub with no functionality. Its purpose is to keep RdfResource compatible.
       #
       def add_necessities (site, page)
         return self
       end
 
       ##
-      # Funktion stub with no funktionality. Its purpose is to keep RdfResource compatible.
+      # Function stub with no functionality. Its purpose is to keep RdfResource compatible.
       #
       def ready?
         return true;
@@ -69,7 +62,7 @@ module Jekyll
       ##
       # Convert this RdfTerm into a string
       # This should be:
-      # - for resoruces: the IRI
+      # - for resources: the IRI
       # - for literals: the literal representation e.g. "Hallo"@de or "123"^^<http://www.w3.org/2001/XMLSchema#integer>
       #
       def to_s
@@ -91,15 +84,14 @@ module Jekyll
       # Convert an RDF term into a new Jekyll::Drops::RdfTerm
       #
       # * +term+ - The term to be represented
-      # * +sparql+ - The SPARQL::Client which contains the represented +term+
       # * +site+ - The Jekyll::Site to be enriched
       #
-      def self.build_term_drop(term, sparql, site)
+      def self.build_term_drop(term, site)
         case term
         when RDF::URI, RDF::Node
-          return RdfResource.new(term, sparql, site)
+          return RdfResource.new(term, site)
         when RDF::Literal
-          return RdfLiteral.new(term, sparql)
+          return RdfLiteral.new(term,)
         else
           return nil
         end

--- a/lib/jekyll/filters/rdf_collection.rb
+++ b/lib/jekyll/filters/rdf_collection.rb
@@ -27,16 +27,12 @@
 module Jekyll
   module RdfCollection
     def rdf_collection(input, predicate = nil)
-      sparql_query = input.sparql
-      unless predicate.nil?
-        predicate = rdf_resolve_prefix(input, predicate)
-      end
       query = "SELECT ?f WHERE{ #{input.term.to_ntriples} " <<
-              (predicate.nil?? "" : " <#{predicate}> ?coll . ?coll ") <<
+              (predicate.nil? ? "" : " <#{rdf_resolve_prefix(predicate)}> ?coll . ?coll ") <<
               " <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>* ?r. ?r <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> ?f}"
       results = []
-      sparql_query.query(query).each{ |solution|
-        results.push Jekyll::Drops::RdfTerm.build_term_drop(solution.f, input.sparql, input.site).add_necessities(input.site, input.page)
+      Jekyll::RdfHelper::sparql.query(query).each{ |solution|
+        results.push Jekyll::Drops::RdfTerm.build_term_drop(solution.f, Jekyll::RdfHelper::site).add_necessities(Jekyll::RdfHelper::site, Jekyll::RdfHelper::page)
       }
       return results
     end

--- a/lib/jekyll/filters/rdf_container.rb
+++ b/lib/jekyll/filters/rdf_container.rb
@@ -27,28 +27,29 @@ module Jekyll
   module RdfContainer
     include Jekyll::RdfPrefixResolver
     def rdf_container(input, type = nil)
-      sparql_client = input.sparql
-      if(!(valid_container?(input, sparql_client, type)))
-        Jekyll.logger.error "#{input.term.to_ntriples} is not recognized as a container"
+      sparql_client = Jekyll::RdfHelper::sparql
+      n_triples = input.term.to_ntriples
+      if(!(valid_container?(n_triples, type)))
+        Jekyll.logger.error "#{n_triples} is not recognized as a container"
         return []
       end
-      query = "SELECT ?p ?o WHERE{ #{input.term.to_ntriples} ?p ?o #{query_additions(input, sparql_client)}"
+      query = "SELECT ?p ?o WHERE{ #{n_triples} ?p ?o #{query_additions()}"
       solutions = sparql_client.query(query).each_with_object([]) {|solution, array|
         if(/^http:\/\/www\.w3\.org\/1999\/02\/22-rdf-syntax-ns#_\d+$/.match(solution.p.to_s))
-          array << Jekyll::Drops::RdfTerm.build_term_drop(solution.o, input.sparql, input.site).add_necessities(input.site, input.page)
+          array << Jekyll::Drops::RdfTerm.build_term_drop(solution.o, Jekyll::RdfHelper::site).add_necessities(Jekyll::RdfHelper::site, Jekyll::RdfHelper::page)
         end
       }
       return solutions
     end
 
-    def query_additions(input, sparql_client)
+    def query_additions()
       return "BIND((<http://www.w3.org/2001/XMLSchema#integer>(SUBSTR(str(?p), 45))) AS ?order) } ORDER BY ASC(?order)"
     end
 
-    def valid_container?(input, sparql_client, type = nil)
-      ask_query1 = "ASK WHERE {VALUES ?o {<http://www.w3.org/2000/01/rdf-schema#Container> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt>} #{input.term.to_ntriples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}"
-      ask_query2 = "ASK WHERE {#{input.term.to_ntriples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o. ?o <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.w3.org/2000/01/rdf-schema#Container>}"
-      return (sparql_client.query(ask_query1).true?) || (sparql_client.query(ask_query2).true?)
+    def valid_container?(n_triples, type = nil)
+      ask_query1 = "ASK WHERE {VALUES ?o {<http://www.w3.org/2000/01/rdf-schema#Container> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt>} #{n_triples} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}"
+      ask_query2 = "ASK WHERE {#{ n_triples } <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o. ?o <http://www.w3.org/2000/01/rdf-schema#subClassOf>* <http://www.w3.org/2000/01/rdf-schema#Container>}"
+      return (Jekyll::RdfHelper::sparql.query(ask_query1).true?) || (Jekyll::RdfHelper::sparql.query(ask_query2).true?)
     end
   end
 end

--- a/lib/jekyll/filters/rdf_property.rb
+++ b/lib/jekyll/filters/rdf_property.rb
@@ -42,8 +42,8 @@ module Jekyll
       return map_predicate(input, predicate, lang, list)
     end
 
-    def rdf_inverse_property(input, predicate, lang = nil, list = false)
-      return map_predicate(input, predicate, lang, list, true)
+    def rdf_inverse_property(input, predicate, list = false)
+      return map_predicate(input, predicate, nil, list, true)
     end
 
     private

--- a/lib/jekyll/filters/rdf_property.rb
+++ b/lib/jekyll/filters/rdf_property.rb
@@ -49,8 +49,8 @@ module Jekyll
     private
     def map_predicate(input, predicate, lang = nil, list = false, inverse = false)
       return input unless input.is_a?(Jekyll::Drops::RdfResource)
-      predicate = rdf_resolve_prefix(input, predicate)
-      result = filter_statements(input, predicate, inverse, lang)
+      predicate = rdf_resolve_prefix(predicate)
+      result = filter_statements(input.term.to_ntriples, predicate, inverse, lang)
       return unless !result.empty?
       if(list)
         return result
@@ -59,34 +59,27 @@ module Jekyll
       end
     end
 
-    private
-    def filter_statements(input, predicate, inverse = false, lang = nil)
-      client = input.sparql
+    def filter_statements(n_triples, predicate, inverse = false, lang = nil)
+      client = Jekyll::RdfHelper::sparql
       query = ""
       if (lang.eql? 'cfg')
-        lang_query = "FILTER(lang(?o) = '#{input.site.config['jekyll_rdf']['language']}')"
+        lang_query = "FILTER(lang(?o) = '#{Jekyll::RdfHelper::site.config['jekyll_rdf']['language']}')"
       elsif lang.nil?
         lang_query = ""
       else
         lang_query = "FILTER(lang(?o) = '#{lang}')"
       end
 
-      if(!input.to_s[0..1].eql? "_:")
-        input_uri = "<#{input.to_s}>"
-      else
-        input_uri = input.to_s
-      end
-
       if(inverse)
-        query = "SELECT ?s WHERE{ ?s <#{predicate}> #{input_uri} }"
+        query = "SELECT ?s WHERE{ ?s <#{predicate}> #{n_triples} }"
         result = client.query(query).map do |solution|
           subject = RDF::URI(solution.s)
-          Jekyll::Drops::RdfResource.new(subject, input.sparql, input.site, input.page)
+          Jekyll::Drops::RdfResource.new(subject, Jekyll::RdfHelper::site, Jekyll::RdfHelper::page)
         end
       else
-        query = "SELECT ?o ?dt ?lit ?lang WHERE{ #{input_uri} <#{predicate}> ?o BIND(datatype(?o) AS ?dt) BIND(isLiteral(?o) AS ?lit) BIND(lang(?o) AS ?lang) #{lang_query} }"
+        query = "SELECT ?o ?dt ?lit ?lang WHERE{ #{n_triples} <#{predicate}> ?o BIND(datatype(?o) AS ?dt) BIND(isLiteral(?o) AS ?lit) BIND(lang(?o) AS ?lang) #{lang_query} }"
         result = client.query(query).map do |solution|
-          dist_literal_resource(input, solution)
+          dist_literal_resource(solution)
         end
       end
       return result
@@ -95,15 +88,14 @@ module Jekyll
     ##
     # Distinguishes the solution between an Literal and a Resource
     #
-    private
-    def dist_literal_resource(input, solution)
+    def dist_literal_resource(solution)
       if solution.lit.true?
         check = check_solution(solution)
         object = RDF::Literal(solution.o, language: check[:lang], datatype: RDF::URI(check[:dataType]))
-        result = Jekyll::Drops::RdfLiteral.new(object, input.sparql)
+        result = Jekyll::Drops::RdfLiteral.new(object)
       else
         object = RDF::URI(solution.o)
-        result = Jekyll::Drops::RdfResource.new(object, input.sparql, input.site, input.page)
+        result = Jekyll::Drops::RdfResource.new(object, Jekyll::RdfHelper::site, Jekyll::RdfHelper::page)
       end
       return result
     end
@@ -111,16 +103,15 @@ module Jekyll
     ##
     # check what language and datatype the passed literal has
     #
-    private
     def check_solution(solution)
-        result = {:lang => nil, :dataType => nil}
-        if((solution.bound?(:lang)) && (!solution.lang.to_s.eql?("")))
-          result[:lang] = solution.lang.to_s.to_sym
-        end
-        if(solution.bound? :dt)
-          result[:dataType] = solution.dt
-        end
-        return result
+      result = {:lang => nil, :dataType => nil}
+      if((solution.bound?(:lang)) && (!solution.lang.to_s.eql?("")))
+        result[:lang] = solution.lang.to_s.to_sym
+      end
+      if(solution.bound? :dt)
+        result[:dataType] = solution.dt
+      end
+      return result
     end
   end
 end

--- a/lib/jekyll/filters/rdf_resolve_prefix.rb
+++ b/lib/jekyll/filters/rdf_resolve_prefix.rb
@@ -26,22 +26,22 @@
 module Jekyll
   module RdfPrefixResolver
     private
-    def rdf_resolve_prefix(input, predicate)
+    def rdf_resolve_prefix(predicate)
       if(predicate[0] == "<" && predicate[-1] == ">")
         return predicate[1..-2]
       end
       arr=predicate.split(":",2)  #bad regex, would also devide 'http://example....' into 'http' and '//example....',even though it is already a complete URI; if 'PREFIX http: <http://...> is defined, 'http' in 'http://example....' could be mistaken for a prefix
       if((arr[1].include? (":")) || (arr[1][0..1].eql?("//")))
-        raise UnMarkedUri.new(predicate, input.page.data['template'])
+        raise UnMarkedUri.new(predicate, Jekyll::RdfHelper::page.data['template'])
       end
-      if(!input.page.data["rdf_prefixes"].nil?)
-        if(!input.page.data["rdf_prefix_map"][arr[0]].nil?)
-          return arr[1].prepend(input.page.data["rdf_prefix_map"][arr[0]])
+      if(!Jekyll::RdfHelper::page.data["rdf_prefixes"].nil?)
+        if(!Jekyll::RdfHelper::page.data["rdf_prefix_map"][arr[0]].nil?)
+          return arr[1].prepend(Jekyll::RdfHelper::page.data["rdf_prefix_map"][arr[0]])
         else
-          raise NoPrefixMapped.new(predicate, input.page.data['template'], arr[0])
+          raise NoPrefixMapped.new(predicate, Jekyll::RdfHelper::page.data['template'], arr[0])
         end
       else
-        raise NoPrefixesDefined.new(predicate, input.page.data['template'])
+        raise NoPrefixesDefined.new(predicate, Jekyll::RdfHelper::page.data['template'])
       end
     end
   end

--- a/lib/jekyll/filters/rdf_sparql_query.rb
+++ b/lib/jekyll/filters/rdf_sparql_query.rb
@@ -37,16 +37,15 @@ module Jekyll
     # * +input+ - the context RDF resource
     # * +query+ - the SPARQL query
     #
-    def sparql_query(input, query)
-      return input unless input.is_a?(Jekyll::Drops::RdfResource)
-      query.gsub!('?resourceUri', "<#{input.term.to_s}>")
-      if(!input.page.data["rdf_prefixes"].nil?)
-        query = query.prepend(" ").prepend(input.page.data["rdf_prefixes"])
+    def sparql_query(query)
+      query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>") #maybe use this part as optional parameter
+      if(!Jekyll::RdfHelper::page.data["rdf_prefixes"].nil?)
+        query = query.prepend(" ").prepend(Jekyll::RdfHelper::page.data["rdf_prefixes"])
       end
       begin
-        result = input.sparql.query(query).map do |solution|
+        result = Jekyll::RdfHelper::sparql.query(query).map do |solution|
           hsh = solution.to_h
-          hsh.update(hsh){ |k,v| Jekyll::Drops::RdfTerm.build_term_drop(v, input.sparql, input.site).add_necessities(input.site, input.page)}
+          hsh.update(hsh){ |k,v| Jekyll::Drops::RdfTerm.build_term_drop(v, Jekyll::RdfHelper::site).add_necessities(Jekyll::RdfHelper::site, Jekyll::RdfHelper::page)}
           hsh.collect{|k,v| [k.to_s, v]}.to_h
         end
         return result

--- a/lib/jekyll/rdf_generator_helper.rb
+++ b/lib/jekyll/rdf_generator_helper.rb
@@ -21,11 +21,11 @@ module Jekyll
         }
       end
 
-      def parse_resources (resources, sparql)
+      def parse_resources (resources)
         @pageResources={};
         @blanknodes=[]
         resources.each do |uri|
-          resource = Jekyll::Drops::RdfResource.new(uri, sparql)
+          resource = Jekyll::Drops::RdfResource.new(uri)
           if(uri.instance_of? RDF::URI)
             uriString = uri.to_s
             if((uriString.include? "#") && (uriString.index("#") < (uriString.length - 1)))   #sorting in uris with a #

--- a/lib/jekyll/rdf_main_generator.rb
+++ b/lib/jekyll/rdf_main_generator.rb
@@ -60,7 +60,7 @@ module Jekyll
       site.data['sparql'] = sparql
       site.data['resources'] = []
 
-      parse_resources(resources, sparql)
+      parse_resources(resources)
 
       mapper = Jekyll::RdfTemplateMapper.new(@config['instance_template_mappings'], @config['class_template_mappings'], @config['default_template'], sparql)
 

--- a/test/ResourceHelper.rb
+++ b/test/ResourceHelper.rb
@@ -10,7 +10,7 @@ class ResourceHelper
   end
 
   def basic_resource(uri)
-    resource = Jekyll::Drops::RdfResource.new(RDF::URI.new(uri), @sparql)
+    resource = Jekyll::Drops::RdfResource.new(RDF::URI.new(uri))
     if(@global_site)
       attach_site(resource, use_global_site())
     else
@@ -21,7 +21,7 @@ class ResourceHelper
   end
 
   def basic_literal(string)
-    literal = Jekyll::Drops::RdfLiteral.new(RDF::Literal.new(string), @sparql)
+    literal = Jekyll::Drops::RdfLiteral.new(RDF::Literal.new(string))
     return literal
   end
 
@@ -57,7 +57,7 @@ class ResourceHelper
     return resource
   end
 
-  def resource_faulty_sparql(uri, exception)  #Fehleranfällig
+  def faulty_sparql_client(exception)  #Fehleranfällig
     faulty_sparql = Object.new
     case exception
     when :ClientError
@@ -73,10 +73,7 @@ class ResourceHelper
         raise Exception
       end
     end
-    resource = Jekyll::Drops::RdfResource.new(RDF::URI.new(uri), faulty_sparql)
-    attach_site(resource, create_fake_site())
-    attach_page(resource, create_fake_page())
-    return resource
+    return faulty_sparql
   end
 
   def create_bad_fetch_site()

--- a/test/source/_layouts/abraham.html
+++ b/test/source/_layouts/abraham.html
@@ -10,7 +10,7 @@ layout: abraham_outer_layout
   <img alt="Abe Simpson.png" src="http://upload.wikimedia.org/wikipedia/en/3/3e/Abe_Simpson.png" width="167" height="300" data-file-width="167" data-file-height="300">
 
   {% assign query = 'SELECT ?sub ?pre WHERE { ?sub ?pre ?resourceUri }' %}
-  {% assign resultset = page.rdf | sparql_query: query %}
+  {% assign resultset = query | sparql_query %}
   <table>
   {% for result in resultset %}
     <tr>

--- a/test/source/_layouts/sparqlDemo.html
+++ b/test/source/_layouts/sparqlDemo.html
@@ -6,7 +6,7 @@
   <body>
     <h1>This is a Sparqldemo</h1>
     {% assign query = "SELECT ?o WHERE{ <http://www.ifi.uio.no/INF3580/simpson-container#Container> ?p ?o }" %}
-    {% assign result = page.rdf | sparql_query: query %}
+    {% assign result = query | sparql_query %}
     {% for res in result %}
       <h4> {{res.o}}</h4>
     {% endfor %}

--- a/test/test_rdf_filters.rb
+++ b/test/test_rdf_filters.rb
@@ -57,7 +57,7 @@ class TestRdfFilter < Test::Unit::TestCase
     end
 
     should "be reversable with all specifications" do
-      answer = rdf_inverse_property(@testResource, "fam:hasFather", nil, true)
+      answer = rdf_inverse_property(@testResource, "fam:hasFather", true)
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Bart"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Bart")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
@@ -88,13 +88,6 @@ class TestRdfFilter < Test::Unit::TestCase
       assert(answer.any? {|solution| (solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/simpsons#Lisa') && (solution['y'].to_s.eql?  'http://www.ifi.uio.no/INF3580/simpsons#Homer')}, "answerset does not contain the pair http://www.ifi.uio.no/INF3580/simpsons#Lisa and http://www.ifi.uio.no/INF3580/simpsons#Homer")
       assert(answer.any? {|solution| (solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/simpsons#Maggie') && (solution['y'].to_s.eql?  'http://www.ifi.uio.no/INF3580/simpsons#Homer')}, "answerset does not contain the pair http://www.ifi.uio.no/INF3580/simpsons#Maggie and http://www.ifi.uio.no/INF3580/simpsons#Homer")
     end
-
-    #should "return the literal if a literal was passed as first argument" do
-    #  literal = res_helper.basic_literal("basic")
-    #  query = "TEST"
-    #  answer = sparql_query(literal, query)
-    #  assert((literal.to_s.eql? answer.to_s), "the literal string does not correspond to the answer string")
-    #end
 
     # These 3 tests are prune to errors if rdf_resource changes to use sparql in its setup process
     should "log a SPARQL::Client::ClientError Exception" do

--- a/test/test_rdf_inspect.rb
+++ b/test/test_rdf_inspect.rb
@@ -21,8 +21,8 @@ class TestRdfResource < Test::Unit::TestCase
 
   context "RdfTerm.inspect" do
     setup do
-      @literal = Jekyll::Drops::RdfLiteral.new("http://a.random/literal", sparql)
-      @term = Jekyll::Drops::RdfTerm.new("http://a.random/term", sparql)
+      @literal = Jekyll::Drops::RdfLiteral.new("http://a.random/literal")
+      @term = Jekyll::Drops::RdfTerm.new("http://a.random/term")
     end
     should "return the class, the object_id and the term of this object" do
       assert_equal "#<RdfLiteral:0x", @literal.inspect[0..14]
@@ -34,7 +34,7 @@ class TestRdfResource < Test::Unit::TestCase
 
   context "RdfStatement.inspect" do
     setup do
-      @statement = Jekyll::Drops::RdfStatement.new(RDF::Statement(RDF::URI("http://example.resource/subject"), RDF::Node("http://example.term/predicate"), RDF::Literal("http://example.literal/object")), sparql, Object.new)
+      @statement = Jekyll::Drops::RdfStatement.new(RDF::Statement(RDF::URI("http://example.resource/subject"), RDF::Node("http://example.term/predicate"), RDF::Literal("http://example.literal/object")), Object.new)
     end
     should "return the class, the object_id and the term of this object" do
       assert_equal "#<RdfStatement:0x", @statement.inspect[0..16]

--- a/test/test_rdf_main_generator.rb
+++ b/test/test_rdf_main_generator.rb
@@ -65,7 +65,7 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
       resources << RDF::URI.new("http://www.ifi.uio.no/INF3580/family#Jeanne")
       resources << RDF::Node.new
       resources << RDF::Node.new
-      parse_resources(resources, sparql)
+      parse_resources(resources)
       assert_equal "http://www.ifi.uio.no/INF3580/simpsons", @pageResources["http://www.ifi.uio.no/INF3580/simpsons"]["./"].to_s
       assert_equal "http://www.ifi.uio.no/INF3580/simpsons#Homer", @pageResources["http://www.ifi.uio.no/INF3580/simpsons"]["Homer"].to_s
       assert_equal "http://www.ifi.uio.no/INF3580/simpsons#Marge", @pageResources["http://www.ifi.uio.no/INF3580/simpsons"]["Marge"].to_s

--- a/test/test_rdf_template_mapper.rb
+++ b/test/test_rdf_template_mapper.rb
@@ -117,17 +117,17 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
 
   context "RdfTerm comparisions" do
     setup do
-      @compare_term = Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"), sparql)
+      @compare_term = Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"))
     end
 
     should "recognize to completly equal terms" do
-      assert (@compare_term.eql? Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"), sparql)), ".eql? does not recognize equality"
-      assert (@compare_term == Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"), sparql)), "== does not recognize equality"
-      assert (@compare_term === Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"), sparql)), "=== does not recognize equality"
+      assert (@compare_term.eql? Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"))), ".eql? does not recognize equality"
+      assert (@compare_term == Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"))), "== does not recognize equality"
+      assert (@compare_term === Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"))), "=== does not recognize equality"
     end
 
     should "recognize differences" do
-      current_term = Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main2"), sparql)
+      current_term = Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main2"))
       assert !(@compare_term.eql? current_term), "RdfTerm comparisons do not find the difference between the iris #{@compare_term} and #{current_term}"
     end
 
@@ -157,12 +157,12 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
     end
 
     should "let === handle to_s implementing Objects" do
-      current_term = Jekyll::Drops::RdfResource.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"), sparql)
+      current_term = Jekyll::Drops::RdfResource.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"))
       assert (@compare_term === current_term), "RdfTerm comparisons should see equality between #{@compare_term} class: #{@compare_term.class} and #{current_term} class: #{current_term.class}"
-      current_term = Jekyll::Drops::RdfResource.new("http://www.ifi.uio.no/INF3580/main", sparql)
+      current_term = Jekyll::Drops::RdfResource.new("http://www.ifi.uio.no/INF3580/main")
       assert (@compare_term === current_term), "RdfTerm comparisons should see equality between #{@compare_term} class: #{@compare_term.class} and #{current_term} class: #{current_term.class}"
-      current_term = Jekyll::Drops::RdfResource.new("http://www.ifi.uio.no/INF3580/main", sparql)
-      current_term_2 = Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"), sparql)
+      current_term = Jekyll::Drops::RdfResource.new("http://www.ifi.uio.no/INF3580/main")
+      current_term_2 = Jekyll::Drops::RdfTerm.new(RDF::URI("http://www.ifi.uio.no/INF3580/main"))
       assert (current_term === current_term_2), "RdfTerm comparisons should see equality between #{current_term} class: #{current_term.class} and #{current_term_2} class: #{current_term_2.class}"
     end
   end


### PR DESCRIPTION
Fix #109 
This pull request also cleans up some of the code to make dataobjects more lightwighted and generally streamline filters. This will **later** also include the support of directly using strings in each filter.

Contained API-changes:
  * <rdf_resource> | sparql_query: [\<query\>]     -->     \<query\> | sparql_query  
  * it is not possible to set a language parameter in rdf_inverse_property