### PR TITLE
Consequent filters

### DIFF
--- a/lib/jekyll/filters/rdf_collection.rb
+++ b/lib/jekyll/filters/rdf_collection.rb
@@ -27,6 +27,7 @@
 module Jekyll
   module RdfCollection
     def rdf_collection(input, predicate = nil)
+      input = Jekyll::RdfHelper::page.data['rdf'] if input.nil?
       query = "SELECT ?f WHERE{ #{input.term.to_ntriples} " <<
               (predicate.nil? ? "" : " <#{rdf_resolve_prefix(predicate)}> ?coll . ?coll ") <<
               " <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>* ?r. ?r <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> ?f}"

--- a/lib/jekyll/filters/rdf_collection.rb
+++ b/lib/jekyll/filters/rdf_collection.rb
@@ -27,7 +27,7 @@
 module Jekyll
   module RdfCollection
     def rdf_collection(input, predicate = nil)
-      input = Jekyll::RdfHelper::page.data['rdf'] if input.nil?
+      input = Jekyll::RdfHelper::page.data['rdf'] if(input.nil? || input.class <= (Jekyll::RdfPageData))
       query = "SELECT ?f WHERE{ #{input.term.to_ntriples} " <<
               (predicate.nil? ? "" : " <#{rdf_resolve_prefix(predicate)}> ?coll . ?coll ") <<
               " <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>* ?r. ?r <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> ?f}"

--- a/lib/jekyll/filters/rdf_container.rb
+++ b/lib/jekyll/filters/rdf_container.rb
@@ -27,6 +27,7 @@ module Jekyll
   module RdfContainer
     include Jekyll::RdfPrefixResolver
     def rdf_container(input, type = nil)
+      input = Jekyll::RdfHelper::page.data['rdf'] if input.nil?
       sparql_client = Jekyll::RdfHelper::sparql
       n_triples = input.term.to_ntriples
       if(!(valid_container?(n_triples, type)))

--- a/lib/jekyll/filters/rdf_container.rb
+++ b/lib/jekyll/filters/rdf_container.rb
@@ -27,7 +27,7 @@ module Jekyll
   module RdfContainer
     include Jekyll::RdfPrefixResolver
     def rdf_container(input, type = nil)
-      input = Jekyll::RdfHelper::page.data['rdf'] if input.nil?
+      input = Jekyll::RdfHelper::page.data['rdf'] if(input.nil? ||  input.class <= (Jekyll::RdfPageData))
       sparql_client = Jekyll::RdfHelper::sparql
       n_triples = input.term.to_ntriples
       if(!(valid_container?(n_triples, type)))

--- a/lib/jekyll/filters/rdf_get.rb
+++ b/lib/jekyll/filters/rdf_get.rb
@@ -31,7 +31,7 @@ module Jekyll
   module RdfGet
     include Jekyll::RdfPrefixResolver
     def rdf_get(request_uri)
-      request_uri = "<#{Jekyll::RdfHelper::page.data['rdf'].term.to_s}>" if request_uri.nil?
+      request_uri = "<#{Jekyll::RdfHelper::page.data['rdf'].term.to_s}>" if (request_uri.nil? || request_uri.class <= (Jekyll::RdfPageData))
       request_uri = rdf_resolve_prefix(request_uri)
       ask_exist = "ASK WHERE {{<#{request_uri}> ?p ?o}UNION{?s <#{request_uri}> ?o}UNION{?s ?p <#{request_uri}>}} "
       return unless (Jekyll::RdfHelper::sparql.query(ask_exist).true?)

--- a/lib/jekyll/filters/rdf_get.rb
+++ b/lib/jekyll/filters/rdf_get.rb
@@ -31,6 +31,7 @@ module Jekyll
   module RdfGet
     include Jekyll::RdfPrefixResolver
     def rdf_get(request_uri)
+      request_uri = "<#{Jekyll::RdfHelper::page.data['rdf'].term.to_s}>" if request_uri.nil?
       request_uri = rdf_resolve_prefix(request_uri)
       ask_exist = "ASK WHERE {{<#{request_uri}> ?p ?o}UNION{?s <#{request_uri}> ?o}UNION{?s ?p <#{request_uri}>}} "
       return unless (Jekyll::RdfHelper::sparql.query(ask_exist).true?)

--- a/lib/jekyll/filters/rdf_property.rb
+++ b/lib/jekyll/filters/rdf_property.rb
@@ -38,7 +38,7 @@ module Jekyll
     # * +lang+ - (optional) preferred language of a the returned object. The precise implementation of choosing which object to return (both in case a language is supplied and in case is not supplied) is undefined
     # * +list+ - (optional) decides the format of the return value. If set to true it returns an array, otherwise it returns a singleton String containing a URI.
     #
-    def rdf_property( input, predicate, lang = nil, list = false)
+    def rdf_property(input, predicate, lang = nil, list = false)
       return map_predicate(input, predicate, lang, list)
     end
 
@@ -48,7 +48,7 @@ module Jekyll
 
     private
     def map_predicate(input, predicate, lang = nil, list = false, inverse = false)
-      input = Jekyll::RdfHelper::page.data['rdf'] if(input.nil?)
+      input = Jekyll::RdfHelper::page.data['rdf'] if(input.nil? ||  input.class <= (Jekyll::RdfPageData))
       return input unless input.is_a?(Jekyll::Drops::RdfResource)
       predicate = rdf_resolve_prefix(predicate)
       result = filter_statements(input.term.to_ntriples, predicate, inverse, lang)

--- a/lib/jekyll/filters/rdf_property.rb
+++ b/lib/jekyll/filters/rdf_property.rb
@@ -38,7 +38,7 @@ module Jekyll
     # * +lang+ - (optional) preferred language of a the returned object. The precise implementation of choosing which object to return (both in case a language is supplied and in case is not supplied) is undefined
     # * +list+ - (optional) decides the format of the return value. If set to true it returns an array, otherwise it returns a singleton String containing a URI.
     #
-    def rdf_property(input, predicate, lang = nil, list = false)
+    def rdf_property( input, predicate, lang = nil, list = false)
       return map_predicate(input, predicate, lang, list)
     end
 
@@ -48,6 +48,7 @@ module Jekyll
 
     private
     def map_predicate(input, predicate, lang = nil, list = false, inverse = false)
+      input = Jekyll::RdfHelper::page.data['rdf'] if(input.nil?)
       return input unless input.is_a?(Jekyll::Drops::RdfResource)
       predicate = rdf_resolve_prefix(predicate)
       result = filter_statements(input.term.to_ntriples, predicate, inverse, lang)

--- a/lib/jekyll/filters/rdf_sparql_query.rb
+++ b/lib/jekyll/filters/rdf_sparql_query.rb
@@ -39,7 +39,7 @@ module Jekyll
     #
     def sparql_query(resource = nil, query)
       if(resource.nil? || resource.class <= (Jekyll::RdfPageData))
-        query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>") #maybe use this part as optional parameter
+        query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>")
       else
         query.gsub!('?resourceUri', "<#{resource}>")
       end

--- a/lib/jekyll/filters/rdf_sparql_query.rb
+++ b/lib/jekyll/filters/rdf_sparql_query.rb
@@ -38,7 +38,7 @@ module Jekyll
     # * +query+ - the SPARQL query
     #
     def sparql_query(resource = nil, query)
-      if(resource.nil?)
+      if(resource.nil? || resource.class <= (Jekyll::RdfPageData))
         query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>") #maybe use this part as optional parameter
       else
         query.gsub!('?resourceUri', "<#{resource}>")

--- a/lib/jekyll/filters/rdf_sparql_query.rb
+++ b/lib/jekyll/filters/rdf_sparql_query.rb
@@ -37,8 +37,12 @@ module Jekyll
     # * +input+ - the context RDF resource
     # * +query+ - the SPARQL query
     #
-    def sparql_query(query)
-      query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>") #maybe use this part as optional parameter
+    def sparql_query(resource = nil, query)
+      if(resource.nil?)
+        query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>") #maybe use this part as optional parameter
+      else
+        query.gsub!('?resourceUri', "<#{resource}>")
+      end
       if(!Jekyll::RdfHelper::page.data["rdf_prefixes"].nil?)
         query = query.prepend(" ").prepend(Jekyll::RdfHelper::page.data["rdf_prefixes"])
       end

--- a/test/test_rdf_filters.rb
+++ b/test/test_rdf_filters.rb
@@ -62,6 +62,18 @@ class TestRdfFilter < Test::Unit::TestCase
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
     end
+
+    should "be able to substitude nil with the page object" do
+      answer = rdf_property(nil, "<http://www.ifi.uio.no/INF3580/family#hasSpouse>")
+      assert_equal(answer.to_s, "http://www.ifi.uio.no/INF3580/simpsons#Marge")
+    end
+
+    should "substitude nil with the page object even in the reverse variant" do
+      answer = rdf_inverse_property(nil, "<http://www.ifi.uio.no/INF3580/family#hasSpouse>")
+      assert_equal("http://www.ifi.uio.no/INF3580/simpsons#Marge", answer.to_s)
+      answer = rdf_inverse_property(nil, "<http://xmlns.com/foaf/0.1/name>")
+      assert_equal("http://placeholder.host.plh/placeholder#TPerson", answer.to_s)
+    end
   end
 
   context "Filter sparql_query from Jekyll::RdfSparqlQuery" do
@@ -87,6 +99,12 @@ class TestRdfFilter < Test::Unit::TestCase
       assert(answer.any? {|solution| (solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/simpsons#Bart') && (solution['y'].to_s.eql?  'http://www.ifi.uio.no/INF3580/simpsons#Homer')}, "answerset does not contain the pair http://www.ifi.uio.no/INF3580/simpsons#Bart and http://www.ifi.uio.no/INF3580/simpsons#Homer")
       assert(answer.any? {|solution| (solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/simpsons#Lisa') && (solution['y'].to_s.eql?  'http://www.ifi.uio.no/INF3580/simpsons#Homer')}, "answerset does not contain the pair http://www.ifi.uio.no/INF3580/simpsons#Lisa and http://www.ifi.uio.no/INF3580/simpsons#Homer")
       assert(answer.any? {|solution| (solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/simpsons#Maggie') && (solution['y'].to_s.eql?  'http://www.ifi.uio.no/INF3580/simpsons#Homer')}, "answerset does not contain the pair http://www.ifi.uio.no/INF3580/simpsons#Maggie and http://www.ifi.uio.no/INF3580/simpsons#Homer")
+    end
+
+    should "properly substitude ?resourceUri with the given resource" do
+      query = "SELECT ?y WHERE{ ?resourceUri foaf:age ?y}"
+      answer = sparql_query(@testResource, query)
+      assert(answer.any? {|solution| solution['y'].to_s.eql?  '36'}, "answer should return the age of Homer Simpson (36)")
     end
 
     # These 3 tests are prune to errors if rdf_resource changes to use sparql in its setup process
@@ -169,16 +187,28 @@ class TestRdfFilter < Test::Unit::TestCase
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
     end
+
+    should "substitude nil with the page resource object" do
+      answer = rdf_collection(nil)
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Homer"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Homer")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Marge"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Marge")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Bart"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Bart")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
+    end
   end
 
-  context "Filter rdf_collection with argument from Jekyll::RdfCollection" do
+  context "Filter rdf_collection with argument from Jekyll::RdfCollection and a predicate as shortcut" do
     setup do
+      Jekyll::RdfHelper.sparql = sparql
       prefixes = {"rdf" => "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs" => "http://www.w3.org/2000/01/rdf-schema#", "foaf" => "http://xmlns.com/foaf/0.1/", "fam" => "http://www.ifi.uio.no/INF3580/family#", "simc" => "http://www.ifi.uio.no/INF3580/simpson-collection#"}
       @testResource = res_helper.resource_with_prefixes_config("http://pcai042.informatik.uni-leipzig.de/~dtp16/#TestEntity", prefixes)
+      Jekyll::RdfHelper.page = @testResource.page
+      Jekyll::RdfHelper.page.data['rdf'] = @testResource
     end
 
     should "return a set of resources stashed in the passed collection" do
-      answer = rdf_collection(@testResource, "<http://pcai042.informatik.uni-leipzig.de/~dtp16/#hasList>")
+      answer = rdf_collection(nil, "<http://pcai042.informatik.uni-leipzig.de/~dtp16/#hasList>")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Homer"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Homer")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Marge"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Marge")
       assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
@@ -192,6 +222,8 @@ class TestRdfFilter < Test::Unit::TestCase
       @testSeq = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#Seq", prefixes)
       @testContainer = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#Container", prefixes)
       @testCustomContainer = res_helper.resource_with_prefixes_config("http://www.ifi.uio.no/INF3580/simpson-container#CustomContainer", prefixes)
+      Jekyll::RdfHelper.page = @testSeq.page
+      Jekyll::RdfHelper.page.data['rdf'] = @testSeq
     end
 
     should "return a set of resources stashed in the passed sequence container" do
@@ -229,6 +261,15 @@ class TestRdfFilter < Test::Unit::TestCase
       resource = res_helper.basic_resource("http://Test")
       assert !(valid_container?(resource.term.to_ntriples)), "validContainer? returned true"
     end
+
+    should "substitude nil with the page resource object" do
+      answer = rdf_container(nil)
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Homer"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Homer")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Marge"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Marge")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Bart"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Bart")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Lisa"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Lisa")
+      assert(answer.any? {|resource| resource.to_s.eql? "http://www.ifi.uio.no/INF3580/simpsons#Maggie"}, "answerset does not contain http://www.ifi.uio.no/INF3580/simpsons#Maggie")
+    end
   end
 
   context "Filter rdf_get from Jekyll::RdfGet" do
@@ -246,6 +287,12 @@ class TestRdfFilter < Test::Unit::TestCase
       assert_equal "http://www.ifi.uio.no/INF3580/main", test_resource.iri
       assert (test_resource.site.eql? Jekyll::RdfHelper::site), "The resource should contain the same site as Jekyll::RdfHelper"
       assert (test_resource.page.eql? Jekyll::RdfHelper::page), "The resource should contain the same page as Jekyll::RdfHelper"
+    end
+
+    should "substitude nil with page resource" do
+      Jekyll::RdfHelper::page.data["rdf"] = res_helper.basic_resource("http://www.ifi.uio.no/INF3580/main")
+      test_resource =  rdf_get(nil)
+      assert_equal "http://www.ifi.uio.no/INF3580/main", test_resource.iri
     end
   end
 end

--- a/test/test_rdf_filters.rb
+++ b/test/test_rdf_filters.rb
@@ -65,7 +65,7 @@ class TestRdfFilter < Test::Unit::TestCase
 
     should "be able to substitude nil with the page object" do
       answer = rdf_property(nil, "<http://www.ifi.uio.no/INF3580/family#hasSpouse>")
-      assert_equal(answer.to_s, "http://www.ifi.uio.no/INF3580/simpsons#Marge")
+      assert_equal("http://www.ifi.uio.no/INF3580/simpsons#Marge", answer.to_s)
     end
 
     should "substitude nil with the page object even in the reverse variant" do


### PR DESCRIPTION
if nil gets passed into a filter as first parameter, the filter switches the first parameter against the page resource (except sparql_query)
sparql_query will now substitude \"?resourceUri\" against the first param instead of the page resource

Fix #120 

This PR allows us to chain filters as described in #120 .