### PR TITLE
sparql_query accepts arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,17 +438,18 @@ http://www.ifi.uio.no/INF3580/simpsons#Maggie
 ```
 
 ### sparql_query
-**Synopsis:** `<rdf_resource> | sparql_query: <query>`
+**Synopsis:** `<rdf_resource> | sparql_query: <query>` **OR** `<reference_array> | sparql_query: <query>`
 
 **Parameters:**
 - `<rdf_resource>` is an RdfResource which will replace `?resourceUri` in the query. To omit this parameter or reference the resource of the current page use `page.rdf`, `page`, or `nil`.
+- `<reference_array>` an array containing IRIs as Strings or `rdf_resource`. They will consecutive replace each `?resourceUri_<index>` in your query.
 - `<query>` a string containing a SPARQL query.
 
 **Description:** Evaluates `query` on the given knowledge base and returns an array of results (result set).
 Each entry object in the result set (result) contains the selected variables as resources or literals.
 You can use `?resourceUri` inside the query to reference the resource which is given as `<rdf_resource>`.
 
-**Examples:**
+**Example (page)**
 ```
 <!--Rendering the page of resource Lisa -->
 {% assign query = 'SELECT ?sub ?pre WHERE { ?sub ?pre ?resourceUri }' %}
@@ -461,10 +462,29 @@ You can use `?resourceUri` inside the query to reference the resource which is g
 ```
 **Result:**
 ```html
+<table>
 <tr><td>http://www.ifi.uio.no/INF3580/simpsons#TheSimpsons</td><td>http://www.ifi.uio.no/INF3580/family#hasFamilyMember</td></tr>
 <tr><td>http://www.ifi.uio.no/INF3580/simpsons#Bart</td><td>http://www.ifi.uio.no/INF3580/family#hasSister</td></tr>
 <tr><td>http://www.ifi.uio.no/INF3580/simpsons#Maggie</td><td>http://www.ifi.uio.no/INF3580/family#hasSister</td></tr>
 ...
+```
+
+**Example (array)**
+```
+{% assign query = 'SELECT ?x WHERE {?resourceUri_0 ?x ?resourceUri_1}' %}
+<!-- something that creates array = ["<http://www.ifi.uio.no/INF3580/simpsons#Homer>", "<http://www.ifi.uio.no/INF3580/simpsons#Marge>"] -->
+{% assign resultset = array | sparql_query: query %}
+<table>
+{% for result in resultset %}
+  <tr><td>{{ result.x }}</td></tr>
+{% endfor %}
+</table>
+```
+**Result:**
+```
+<table>
+  <tr><td>http://www.ifi.uio.no/INF3580/family#hasSpouse</td></tr>
+</table>
 ```
 
 ### rdf_container

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ http://www.ifi.uio.no/INF3580/simpsons#Maggie
 
 **Parameters:**
 - `<rdf_resource>` is an RdfResource which will replace `?resourceUri` in the query. To omit this parameter or reference the resource of the current page use `page.rdf`, `page`, or `nil`.
-- `<reference_array>` an array containing IRIs as Strings or `rdf_resource`. They will consecutive replace each `?resourceUri_<index>` in your query.
+- `<reference_array>` an array containing IRIs as Strings or `rdf_resource`. They will consecutively replace each `?resourceUri_<index>` in your query.
 - `<query>` a string containing a SPARQL query.
 
 **Description:** Evaluates `query` on the given knowledge base and returns an array of results (result set).

--- a/lib/jekyll/filters/rdf_sparql_query.rb
+++ b/lib/jekyll/filters/rdf_sparql_query.rb
@@ -29,7 +29,7 @@ module Jekyll
   # Internal module to hold the medthod #sparql_query
   #
   module RdfSparqlQuery
-
+    include Jekyll::RdfPrefixResolver
     ##
     # Executes a SPARQL query. The supplied query is augmented by replacing each occurence of '?resourceUri' by the URI of the context RDF resource.
     # Returns an Array of bindings. Each binding is a Hash mapping variables to their values.
@@ -40,6 +40,14 @@ module Jekyll
     def sparql_query(resource = nil, query)
       if(resource.nil? || resource.class <= (Jekyll::RdfPageData))
         query.gsub!('?resourceUri', "<#{Jekyll::RdfHelper::page.data['rdf'].term}>")
+      elsif(resource.class <= Array)
+        resource.each_with_index do |uri, index|
+          if(uri.class <= Jekyll::Drops::RdfResource)
+            query.gsub!("?resourceUri_#{index-1}", uri.term.to_ntriples)
+          else
+            query.gsub!("?resourceUri_#{index-1}", rdf_resolve_prefix(uri.to_s))
+          end
+        end
       else
         query.gsub!('?resourceUri', "<#{resource}>")
       end

--- a/lib/jekyll/filters/rdf_sparql_query.rb
+++ b/lib/jekyll/filters/rdf_sparql_query.rb
@@ -43,9 +43,9 @@ module Jekyll
       elsif(resource.class <= Array)
         resource.each_with_index do |uri, index|
           if(uri.class <= Jekyll::Drops::RdfResource)
-            query.gsub!("?resourceUri_#{index-1}", uri.term.to_ntriples)
+            query.gsub!("?resourceUri_#{index}", uri.term.to_ntriples)
           else
-            query.gsub!("?resourceUri_#{index-1}", rdf_resolve_prefix(uri.to_s))
+            query.gsub!("?resourceUri_#{index}", "<#{rdf_resolve_prefix(uri.to_s)}>")
           end
         end
       else

--- a/test/test_rdf_filters.rb
+++ b/test/test_rdf_filters.rb
@@ -107,6 +107,15 @@ class TestRdfFilter < Test::Unit::TestCase
       assert(answer.any? {|solution| solution['y'].to_s.eql?  '36'}, "answer should return the age of Homer Simpson (36)")
     end
 
+    should "properly substitude ?resourceUri_#num with a given set of resource" do
+      query = "SELECT ?x WHERE {?resourceUri_1 ?x ?resourceUri_2}"
+      answer = sparql_query([Jekyll::Drops::RdfResource.new(RDF::URI.new("http://www.ifi.uio.no/INF3580/simpsons#Homer")), Jekyll::Drops::RdfResource.new(RDF::URI.new("http://www.ifi.uio.no/INF3580/simpsons#Marge"))], query)
+      assert(answer.any? {|solution| solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/family#hasSpouse'}, "answerset should contain http://www.ifi.uio.no/INF3580/family#hasSpouse.\n    Returned answers:\n     #{answer.inspect}")
+      query = "SELECT ?x WHERE {?resourceUri_1 ?x ?resourceUri_2}"
+      answer = sparql_query(["<http://www.ifi.uio.no/INF3580/simpsons#Homer>", "<http://www.ifi.uio.no/INF3580/simpsons#Marge>"], query)
+      assert(answer.any? {|solution| solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/family#hasSpouse'}, "answerset should contain http://www.ifi.uio.no/INF3580/family#hasSpouse.\n    Returned answers:\n     #{answer.inspect}")
+    end
+
     # These 3 tests are prune to errors if rdf_resource changes to use sparql in its setup process
     should "log a SPARQL::Client::ClientError Exception" do
       Jekyll::RdfHelper::sparql = res_helper.faulty_sparql_client(:ClientError)

--- a/test/test_rdf_filters.rb
+++ b/test/test_rdf_filters.rb
@@ -108,10 +108,10 @@ class TestRdfFilter < Test::Unit::TestCase
     end
 
     should "properly substitude ?resourceUri_#num with a given set of resource" do
-      query = "SELECT ?x WHERE {?resourceUri_1 ?x ?resourceUri_2}"
+      query = "SELECT ?x WHERE {?resourceUri_0 ?x ?resourceUri_1}"
       answer = sparql_query([Jekyll::Drops::RdfResource.new(RDF::URI.new("http://www.ifi.uio.no/INF3580/simpsons#Homer")), Jekyll::Drops::RdfResource.new(RDF::URI.new("http://www.ifi.uio.no/INF3580/simpsons#Marge"))], query)
       assert(answer.any? {|solution| solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/family#hasSpouse'}, "answerset should contain http://www.ifi.uio.no/INF3580/family#hasSpouse.\n    Returned answers:\n     #{answer.inspect}")
-      query = "SELECT ?x WHERE {?resourceUri_1 ?x ?resourceUri_2}"
+      query = "SELECT ?x WHERE {?resourceUri_0 ?x ?resourceUri_1}"
       answer = sparql_query(["<http://www.ifi.uio.no/INF3580/simpsons#Homer>", "<http://www.ifi.uio.no/INF3580/simpsons#Marge>"], query)
       assert(answer.any? {|solution| solution['x'].to_s.eql? 'http://www.ifi.uio.no/INF3580/family#hasSpouse'}, "answerset should contain http://www.ifi.uio.no/INF3580/family#hasSpouse.\n    Returned answers:\n     #{answer.inspect}")
     end


### PR DESCRIPTION
Fix #121 

sparql_query now accepts an array to substitute a consecutive list of ?resourceUri_num in query against the arrays content