### PR TITLE
Path generation with development enviroment

### DIFF
--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -116,6 +116,12 @@ module Jekyll #:nodoc:
           @filename ||= generate_file_name(domain_name, baseurl)
         end
 
+        def filedir
+          return @filedir unless @filedir.nil?
+          generate_file_name(@site.config["url"], @site.config["baseurl"])  #TODO change to RdfHelper.... like page_url
+          @filedir
+        end
+
         def direct_classes
           @direct_classes ||= begin
             classes=[]
@@ -267,6 +273,7 @@ module Jekyll #:nodoc:
               # opaque jekyll produces static pages, so we do not dereferencing
               # query queries do not address resources
               # file_name << "#/#{uri[:fragment]}" unless uri[:fragment].nil? fragments are not evaluated by browsers, only by clients
+
             rescue Addressable::URI::InvalidURIError => x
               file_name = "invalids/#{term.to_s}"
               Jekyll.logger.error("Invalid resource found: #{term.to_s} is not a proper uri")
@@ -278,7 +285,7 @@ module Jekyll #:nodoc:
           if(file_name[-2..-1] == "#/")
             file_name = file_name[0..-3]
           end
-          if(file_name[-1] == '/' || (file_name.eql? ""))
+          if(file_name[-1].eql? '/' || (file_name.eql? ""))
             file_name << "index.html"
           else
             last_slash = file_name.rindex('/')
@@ -290,9 +297,14 @@ module Jekyll #:nodoc:
               file_name[last_slash..-1] = "#{file_name[last_slash..-1]}.html"
             end
           end
+
           @render_path = file_name
           @page_url = "#{file_name.chomp('index.html').chomp('.html')}#{ending}#{fragment_holder}"
-          file_name
+
+          last_slash = file_name.rindex('/').to_i
+          @filedir = file_name[0..last_slash].to_s
+          @filename = file_name[(last_slash + 1)..-1].to_s
+          @filename
         end
       end
 

--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -252,8 +252,8 @@ module Jekyll #:nodoc:
         #
         def generate_file_name()
           fragment_holder = nil
-          domain_name = URI::split(Jekyll::JekyllRdf::Helper::RdfHelper::config["url"])[2].to_s
-          baseurl = Jekyll::JekyllRdf::Helper::RdfHelper::config["baseurl"].to_s
+          domain_name = URI::split(Jekyll::JekyllRdf::Helper::RdfHelper::domainiri)[2].to_s
+          baseurl = Jekyll::JekyllRdf::Helper::RdfHelper::pathiri.to_s
           (("/".eql? baseurl[-1]) || (baseurl.empty? && ("/".eql? domain_name[-1]))) ? rdfsites="rdfsites/": rdfsites="/rdfsites/"
           if(term.to_s[0..1].eql? "_:")
             file_name = "#{rdfsites}blanknode/#{term.to_s.gsub('_:','blanknode_')}/" # ':' can not be used on windows

--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -112,13 +112,15 @@ module Jekyll #:nodoc:
         ##
         # Return a filename corresponding to the RDF resource represented by the receiver. The mapping between RDF resources and filenames should be bijective.
         #
-        def filename(domain_name, baseurl)
-          @filename ||= generate_file_name(domain_name, baseurl)
+        def filename
+          return @filename unless @filename.nil?
+          generate_file_name()
+          @filename
         end
 
         def filedir
           return @filedir unless @filedir.nil?
-          generate_file_name(Jekyll::JekyllRdf::Helper::RdfHelper::site.config["url"], Jekyll::JekyllRdf::Helper::RdfHelper::site.config["baseurl"])
+          generate_file_name()
           @filedir
         end
 
@@ -139,7 +141,7 @@ module Jekyll #:nodoc:
         #
         def page_url
           return @page_url unless @page_url.nil?
-          generate_file_name(@site.config["url"], @site.config["baseurl"])
+          generate_file_name()
           @page_url
         end
 
@@ -148,7 +150,7 @@ module Jekyll #:nodoc:
         #
         def render_path
           return @render_path unless @page_url.nil?
-          generate_file_name(@site.config["url"], @site.config["baseurl"])
+          generate_file_name()
           @render_path
         end
 
@@ -248,10 +250,10 @@ module Jekyll #:nodoc:
         # Generate a filename corresponding to the RDF resource represented by the receiver. The mapping between RDF resources and filenames should be bijective. If the url of the rdf is the same as of the hosting site it will be omitted.
         # * +domain_name+
         #
-        def generate_file_name(domain_name, baseurl)
+        def generate_file_name()
           fragment_holder = nil
-          domain_name = domain_name.to_s
-          baseurl = baseurl.to_s
+          domain_name = URI::split(Jekyll::JekyllRdf::Helper::RdfHelper::config["url"])[2].to_s
+          baseurl = Jekyll::JekyllRdf::Helper::RdfHelper::config["baseurl"].to_s
           (("/".eql? baseurl[-1]) || (baseurl.empty? && ("/".eql? domain_name[-1]))) ? rdfsites="rdfsites/": rdfsites="/rdfsites/"
           if(term.to_s[0..1].eql? "_:")
             file_name = "#{rdfsites}blanknode/#{term.to_s.gsub('_:','blanknode_')}/" # ':' can not be used on windows
@@ -300,7 +302,7 @@ module Jekyll #:nodoc:
           if(file_name[-2..-1] == "#/")
             file_name = file_name[0..-3]
           end
-          if(file_name[-1].eql? '/' || (file_name.eql? ""))
+          if(file_name[-1] == '/' || (file_name.eql? ""))
             file_name << "index.html"
           else
             last_slash = file_name.rindex('/')
@@ -312,7 +314,6 @@ module Jekyll #:nodoc:
               file_name[last_slash..-1] = "#{file_name[last_slash..-1]}.html"
             end
           end
-
           @render_path = file_name
           @page_url = "#{file_name.chomp('index.html').chomp('.html')}#{ending}#{fragment_holder}"
           identify_name_from_path(file_name)

--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -228,6 +228,22 @@ module Jekyll #:nodoc:
           return RdfStatement.new(RDF::Statement( subject, predicate, object), @site)
         end
 
+        def identify_name_from_path(path)
+          begin
+            @filedir = ""
+            @filename = ""
+            return
+          end if((path.nil?)||(path.length <= 0)) # no path supplied
+          last_slash = path.rindex('/')
+          if(last_slash.nil?)
+            @filedir = ""
+            @filename = path
+          else
+            @filedir = path[0..last_slash]
+            @filename = path[(last_slash +1)..-1]
+          end
+        end
+
         ##
         # Generate a filename corresponding to the RDF resource represented by the receiver. The mapping between RDF resources and filenames should be bijective. If the url of the rdf is the same as of the hosting site it will be omitted.
         # * +domain_name+
@@ -273,7 +289,6 @@ module Jekyll #:nodoc:
               # opaque jekyll produces static pages, so we do not dereferencing
               # query queries do not address resources
               # file_name << "#/#{uri[:fragment]}" unless uri[:fragment].nil? fragments are not evaluated by browsers, only by clients
-
             rescue Addressable::URI::InvalidURIError => x
               file_name = "invalids/#{term.to_s}"
               Jekyll.logger.error("Invalid resource found: #{term.to_s} is not a proper uri")
@@ -300,10 +315,7 @@ module Jekyll #:nodoc:
 
           @render_path = file_name
           @page_url = "#{file_name.chomp('index.html').chomp('.html')}#{ending}#{fragment_holder}"
-
-          last_slash = file_name.rindex('/').to_i
-          @filedir = file_name[0..last_slash].to_s
-          @filename = file_name[(last_slash + 1)..-1].to_s
+          identify_name_from_path(file_name)
           @filename
         end
       end

--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -118,7 +118,7 @@ module Jekyll #:nodoc:
 
         def filedir
           return @filedir unless @filedir.nil?
-          generate_file_name(@site.config["url"], @site.config["baseurl"])  #TODO change to RdfHelper.... like page_url
+          generate_file_name(Jekyll::JekyllRdf::Helper::RdfHelper::site.config["url"], Jekyll::JekyllRdf::Helper::RdfHelper::site.config["baseurl"])
           @filedir
         end
 

--- a/lib/jekyll/helper/rdf_general_helper.rb
+++ b/lib/jekyll/helper/rdf_general_helper.rb
@@ -80,6 +80,14 @@ module Jekyll
           end
         end
 
+        def self.config= config
+          @@config = config
+        end
+
+        def self.config
+          @@config
+        end
+
         def self.prefixes
           if(@@usePage)
             return @@page.data

--- a/lib/jekyll/helper/rdf_general_helper.rb
+++ b/lib/jekyll/helper/rdf_general_helper.rb
@@ -80,20 +80,28 @@ module Jekyll
           end
         end
 
-        def self.config= config
-          @@config = config
-        end
-
-        def self.config
-          @@config
-        end
-
         def self.prefixes
           if(@@usePage)
             return @@page.data
           else
             return @@prefixes
           end
+        end
+
+        def self.domainiri= domain
+          @@domainiri = domain
+        end
+
+        def self.domainiri
+          @@domainiri
+        end
+
+        def self.pathiri= path
+          @@baseiri = path
+        end
+
+        def self.pathiri
+          @@baseiri
         end
       end
 

--- a/lib/jekyll/helper/rdf_generator_helper.rb
+++ b/lib/jekyll/helper/rdf_generator_helper.rb
@@ -53,13 +53,25 @@ module Jekyll
           end
 
           @global_config = Jekyll.configuration({})
-
           #small fix because global_config doesn't work in a test enviorment
           if(!@global_config.key? "url")
             @global_config["url"] = site.config["url"]
             @global_config["baseurl"] = site.config["baseurl"]
           end
-          Jekyll::JekyllRdf::Helper::RdfHelper::config = @global_config
+
+          if(@config["baseiri"].nil?)
+            Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = @global_config["url"]
+            Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = @global_config["baseurl"]
+          else
+            uri = Addressable::URI.parse(@config["baseiri"]).to_hash
+            domainuri = ""
+            domainuri << "#{uri[:scheme]}://" unless uri[:scheme].nil?
+            domainuri << "#{uri[:userinfo]}@" unless uri[:userinfo].nil?
+            domainuri << "#{uri[:host]}" unless uri[:host].nil?
+            domainuri << ":#{uri[:port]}" unless uri[:port].nil?
+            Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = domainuri
+            Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = uri[:path][0..-1].to_s unless uri[:path].nil?
+          end
           return true
         end
         ##

--- a/lib/jekyll/helper/rdf_generator_helper.rb
+++ b/lib/jekyll/helper/rdf_generator_helper.rb
@@ -59,6 +59,7 @@ module Jekyll
             @global_config["url"] = site.config["url"]
             @global_config["baseurl"] = site.config["baseurl"]
           end
+          Jekyll::JekyllRdf::Helper::RdfHelper::config = @global_config
           return true
         end
         ##

--- a/lib/jekyll/rdf_page_data.rb
+++ b/lib/jekyll/rdf_page_data.rb
@@ -42,7 +42,7 @@ module Jekyll
     def initialize(site, base, resource, mapper, config)
       @site = site
       @base = base
-      @name = resource.filename(URI::split(config['url'])[2], config['baseurl'])
+      @name = resource.filename
       @dir = resource.filedir
       @resource = resource
       if(base.nil?)

--- a/lib/jekyll/rdf_page_data.rb
+++ b/lib/jekyll/rdf_page_data.rb
@@ -42,8 +42,8 @@ module Jekyll
     def initialize(site, base, resource, mapper, config)
       @site = site
       @base = base
-      @dir = ""
       @name = resource.filename(URI::split(config['url'])[2], config['baseurl'])
+      @dir = resource.filedir
       @resource = resource
       if(base.nil?)
         Jekyll.logger.warn "Resource #{resource} not rendered: no base url found."
@@ -58,7 +58,7 @@ module Jekyll
       end
       load_data(site)
       load_prefixes_yaml()
-      self.data['permalink'] = @name    #overwrite permalinks to stop them from interfering with JekyllRdfs rendersystem
+      self.data['permalink'] = File.join(@dir, @name)    #overwrite permalinks to stop them from interfering with JekyllRdfs rendersystem
       resource.page = self
       resource.site = site
       site.data['resources'] << resource

--- a/test/test_jekyll-rdf.rb
+++ b/test/test_jekyll-rdf.rb
@@ -6,7 +6,7 @@ class TestJekyllRdf < Test::Unit::TestCase
   site = Jekyll::Site.new(config)
   site.process
   simpson_page = site.pages.find{|p|
-    p.name == "/simpsons.html".gsub(TestHelper::BASE_URL, '')
+    p.name == "simpsons.html".gsub(TestHelper::BASE_URL, '')
   }
   context "Generating a site with RDF data" do
     should "create a file which mentions 'Lisa Simpson'" do

--- a/test/test_rdf_main_generator.rb
+++ b/test/test_rdf_main_generator.rb
@@ -15,6 +15,15 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
       assert_equal("/INF3580", @global_config["baseurl"])
     end
 
+    should "load baseiri if available" do
+      Jekyll.logger.warn "enter"
+      test_config = Jekyll.configuration({"url" => "http://www.ifi.uio.no", "baseurl" => "/INF3580", "jekyll_rdf" => {"baseiri" => "http://www.example.org/path/to/our/special/resource"}})
+      site = Jekyll::Site.new(test_config)
+      load_config(site)
+      assert_equal "http://www.example.org", Jekyll::JekyllRdf::Helper::RdfHelper::domainiri
+      assert_equal "/path/to/our/special/resource", Jekyll::JekyllRdf::Helper::RdfHelper::pathiri
+    end
+
     should "fail if jekyll-rdf is included but not configured" do
       TestHelper::setErrOutput
       @site = res_helper.create_bad_fetch_site()

--- a/test/test_rdf_page_data.rb
+++ b/test/test_rdf_page_data.rb
@@ -244,4 +244,27 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
       assert_equal "c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta"), @site).page_url
     end
   end
+
+  context "RdfResource" do
+    should "correctly disect its iri into file name and file directory" do
+      resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
+      assert_equal "a.html", resource.filename("http://ex.org", "/blog/")
+      assert_equal "bla/", resource.filedir
+      resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
+      assert_equal "a.html", resource.filename("http://ex.org", "")
+      assert_equal "/blog/bla/", resource.filedir
+    end
+
+    should "set the filedir to rdfsites/... if the site url and baseurl coincides with the resource iri" do
+      resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
+      assert_equal "a.html", resource.filename("", "")
+      assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
+      resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
+      assert_equal "a.html", resource.filename("http://ex.orgs", "")
+      assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
+      resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
+      assert_equal "a.html", resource.filename("http://ex.orgd", "/blog/s")
+      assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
+    end
+  end
 end

--- a/test/test_rdf_page_data.rb
+++ b/test/test_rdf_page_data.rb
@@ -127,143 +127,170 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
       page1 = Jekyll::RdfPageData.new(site, nil, @resource1, @mapper, config)
       assert !page1.complete, "exit parameter was expected to be false, but it is true"
     end
+
+    should "should create pages with page.name and page.dir reflecting their resources iri" do
+      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog" })
+      config = Jekyll.configuration(TestHelper::TEST_OPTIONS)
+      site = Jekyll::Site.new(config)
+      site.data['resources'] = []
+      page1 = Jekyll::RdfPageData.new(site, File.join(File.dirname(__FILE__), "source"), Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/")), @mapper, config)
+      assert_equal "index.html", page1.name
+      assert_equal "/b/y/", page1.dir
+      page2 = Jekyll::RdfPageData.new(site, File.join(File.dirname(__FILE__), "source"), Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/bla/a")), @mapper, config)
+      assert_equal "a.html", page2.name
+      assert_equal "/bla/", page2.dir
+      page3 = Jekyll::RdfPageData.new(site, File.join(File.dirname(__FILE__), "source"), Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/")), @mapper, config)
+      assert_equal "index.html", page3.name
+      assert_equal "/rdfsites/http/ex.org/b/y/", page3.dir
+    end
   end
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with empty baseurl"do
     setup do
-      @config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "" })
-      @site = Jekyll::Site.new(@config)
+      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "" })
+
     end
 
     should "correctly render simple urls" do
-      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).render_path
-      assert_equal "/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).page_url
-      assert_equal "/b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/"), @site).render_path
-      assert_equal "/b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/"), @site).page_url
-      assert_equal "/b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x"), @site).render_path
-      assert_equal "/b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x"), @site).page_url
-      assert_equal "/b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/"), @site).render_path
-      assert_equal "/b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/"), @site).page_url
-      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html"), @site).render_path
-      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html"), @site).page_url
+      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).render_path
+      assert_equal "/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).page_url
+      assert_equal "/b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/")).render_path
+      assert_equal "/b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/")).page_url
+      assert_equal "/b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x")).render_path
+      assert_equal "/b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x")).page_url
+      assert_equal "/b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/")).render_path
+      assert_equal "/b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/")).page_url
+      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html")).render_path
+      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html")).page_url
     end
 
     should "let fragment-identifier default to super resource" do
-      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha"), @site).render_path
-      assert_equal "/c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha"), @site).page_url
-      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta"), @site).render_path
-      assert_equal "/c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta"), @site).page_url
+      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha")).render_path
+      assert_equal "/c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha")).page_url
+      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta")).render_path
+      assert_equal "/c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta")).page_url
     end
   end
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with '/' as baseurl"do
     setup do
-      @config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/" })
-      @site = Jekyll::Site.new(@config)
+      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/" })
     end
 
     should "correctly render simple urls" do
-      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).render_path
-      assert_equal "a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).page_url
-      assert_equal "b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/"), @site).render_path
-      assert_equal "b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/"), @site).page_url
-      assert_equal "b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x"), @site).render_path
-      assert_equal "b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x"), @site).page_url
-      assert_equal "b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/"), @site).render_path
-      assert_equal "b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/"), @site).page_url
-      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html"), @site).render_path
-      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html"), @site).page_url
+      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).render_path
+      assert_equal "a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).page_url
+      assert_equal "b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/")).render_path
+      assert_equal "b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/")).page_url
+      assert_equal "b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x")).render_path
+      assert_equal "b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/x")).page_url
+      assert_equal "b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/")).render_path
+      assert_equal "b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/b/y/")).page_url
+      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html")).render_path
+      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a.html")).page_url
     end
 
     should "let fragment-identifier default to super resource" do
-      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha"), @site).render_path
-      assert_equal "c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha"), @site).page_url
-      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta"), @site).render_path
-      assert_equal "c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta"), @site).page_url
+      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha")).render_path
+      assert_equal "c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#alpha")).page_url
+      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta")).render_path
+      assert_equal "c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/c#beta")).page_url
     end
   end
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with subdirectory baseurl"do
     setup do
-      @config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog" })
-      @site = Jekyll::Site.new(@config)
+      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog" })
     end
 
     should "correctly render simple urls" do
-      assert_equal "/bla/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/bla/a"), @site).render_path
-      assert_equal "/rdfsites/http/ex.org/bla/blog/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/bla/blog/a"), @site).render_path
-      assert_equal "/rdfsites/http/ex.org/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).render_path
-      assert_equal "/rdfsites/http/ex.org/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).page_url
-      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a"), @site).render_path
-      assert_equal "/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a"), @site).page_url
-      assert_equal "/b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/"), @site).render_path
-      assert_equal "/b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/"), @site).page_url
-      assert_equal "/b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x"), @site).render_path
-      assert_equal "/b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x"), @site).page_url
-      assert_equal "/b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/"), @site).render_path
-      assert_equal "/b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/"), @site).page_url
-      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html"), @site).render_path
-      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html"), @site).page_url
+      assert_equal "/bla/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/bla/a")).render_path
+      assert_equal "/rdfsites/http/ex.org/bla/blog/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/bla/blog/a")).render_path
+      assert_equal "/rdfsites/http/ex.org/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).render_path
+      assert_equal "/rdfsites/http/ex.org/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).page_url
+      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a")).render_path
+      assert_equal "/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a")).page_url
+      assert_equal "/b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/")).render_path
+      assert_equal "/b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/")).page_url
+      assert_equal "/b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x")).render_path
+      assert_equal "/b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x")).page_url
+      assert_equal "/b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/")).render_path
+      assert_equal "/b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/")).page_url
+      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html")).render_path
+      assert_equal "/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html")).page_url
     end
 
     should "let fragment-identifier default to super resource" do
-      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha"), @site).render_path
-      assert_equal "/c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha"), @site).page_url
-      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta"), @site).render_path
-      assert_equal "/c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta"), @site).page_url
+      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha")).render_path
+      assert_equal "/c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha")).page_url
+      assert_equal "/c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta")).render_path
+      assert_equal "/c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta")).page_url
     end
   end
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with subdirectory baseurl ending with slash"do
     setup do
-      @config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog/" })
-      @site = Jekyll::Site.new(@config)
+      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog/" })
     end
 
     should "correctly render simple urls" do
-      assert_equal "bla/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/bla/a"), @site).render_path
-      assert_equal "rdfsites/http/ex.org/bla/blog/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/bla/blog/a"), @site).render_path
-      assert_equal "rdfsites/http/ex.org/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).render_path
-      assert_equal "rdfsites/http/ex.org/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a"), @site).page_url
-      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a"), @site).render_path
-      assert_equal "a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a"), @site).page_url
-      assert_equal "b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/"), @site).render_path
-      assert_equal "b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/"), @site).page_url
-      assert_equal "b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x"), @site).render_path
-      assert_equal "b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x"), @site).page_url
-      assert_equal "b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/"), @site).render_path
-      assert_equal "b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/"), @site).page_url
-      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html"), @site).render_path
-      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html"), @site).page_url
+      assert_equal "bla/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/bla/a")).render_path
+      assert_equal "rdfsites/http/ex.org/bla/blog/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/bla/blog/a")).render_path
+      assert_equal "rdfsites/http/ex.org/a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).render_path
+      assert_equal "rdfsites/http/ex.org/a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/a")).page_url
+      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a")).render_path
+      assert_equal "a", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a")).page_url
+      assert_equal "b/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/")).render_path
+      assert_equal "b/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/")).page_url
+      assert_equal "b/x.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x")).render_path
+      assert_equal "b/x", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/x")).page_url
+      assert_equal "b/y/index.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/")).render_path
+      assert_equal "b/y/", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/b/y/")).page_url
+      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html")).render_path
+      assert_equal "a.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/a.html")).page_url
     end
 
     should "let fragment-identifier default to super resource" do
-      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha"), @site).render_path
-      assert_equal "c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha"), @site).page_url
-      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta"), @site).render_path
-      assert_equal "c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta"), @site).page_url
+      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha")).render_path
+      assert_equal "c#alpha", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#alpha")).page_url
+      assert_equal "c.html", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta")).render_path
+      assert_equal "c#beta", Jekyll::JekyllRdf::Drops::RdfResource.new(RDF::URI("http://ex.org/blog/c#beta")).page_url
     end
   end
 
   context "RdfResource" do
+    setup do
+      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => '/blog/'})
+    end
+
     should "correctly disect its iri into file name and file directory" do
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      assert_equal "a.html", resource.filename("http://ex.org", "/blog/")
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = "/blog/"
+      assert_equal "a.html", resource.filename
       assert_equal "bla/", resource.filedir
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      assert_equal "a.html", resource.filename("http://ex.org", "")
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = ""
+      assert_equal "a.html", resource.filename
       assert_equal "/blog/bla/", resource.filedir
     end
 
     should "set the filedir to rdfsites/... if the site url and baseurl coincides with the resource iri" do
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      assert_equal "a.html", resource.filename("", "")
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = ""
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = ""
+      assert_equal "a.html", resource.filename
       assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      assert_equal "a.html", resource.filename("http://ex.orgs", "")
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = "t"
+      assert_equal "a.html", resource.filename
       assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      assert_equal "a.html", resource.filename("http://ex.orgd", "/blog/s")
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = "/blog/s"
+      assert_equal "a.html", resource.filename
       assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
     end
   end

--- a/test/test_rdf_page_data.rb
+++ b/test/test_rdf_page_data.rb
@@ -129,7 +129,6 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
     end
 
     should "should create pages with page.name and page.dir reflecting their resources iri" do
-      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog" })
       config = Jekyll.configuration(TestHelper::TEST_OPTIONS)
       site = Jekyll::Site.new(config)
       site.data['resources'] = []
@@ -145,10 +144,10 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
     end
   end
 
-  context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with empty baseurl"do
+  context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with empty baseurl" do
     setup do
-      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "" })
-
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = ""
     end
 
     should "correctly render simple urls" do
@@ -174,7 +173,8 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with '/' as baseurl"do
     setup do
-      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/" })
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = "/"
     end
 
     should "correctly render simple urls" do
@@ -200,7 +200,8 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with subdirectory baseurl"do
     setup do
-      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog" })
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = "/blog"
     end
 
     should "correctly render simple urls" do
@@ -230,7 +231,8 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
 
   context "Jekyll::JekyllRdf::Drops::RdfResource.render_path with subdirectory baseurl ending with slash"do
     setup do
-      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => "/blog/" })
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = "/blog/"
     end
 
     should "correctly render simple urls" do
@@ -259,37 +261,33 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
   end
 
   context "RdfResource" do
-    setup do
-      Jekyll::JekyllRdf::Helper::RdfHelper::config = Jekyll.configuration({'url' => "http://ex.org", 'baseurl' => '/blog/'})
-    end
-
     should "correctly disect its iri into file name and file directory" do
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = "/blog/"
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = "/blog/"
       assert_equal "a.html", resource.filename
       assert_equal "bla/", resource.filedir
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = ""
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = ""
       assert_equal "a.html", resource.filename
       assert_equal "/blog/bla/", resource.filedir
     end
 
     should "set the filedir to rdfsites/... if the site url and baseurl coincides with the resource iri" do
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = ""
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = ""
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = ""
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = ""
       assert_equal "a.html", resource.filename
       assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = "t"
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = "t"
       assert_equal "a.html", resource.filename
       assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
       resource = Jekyll::JekyllRdf::Drops::RdfResource.new("http://ex.org/blog/bla/a")
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['url'] = "http://ex.org"
-      Jekyll::JekyllRdf::Helper::RdfHelper::config['baseurl'] = "/blog/s"
+      Jekyll::JekyllRdf::Helper::RdfHelper::domainiri = "http://ex.org"
+      Jekyll::JekyllRdf::Helper::RdfHelper::pathiri = "/blog/s"
       assert_equal "a.html", resource.filename
       assert_equal "/rdfsites/http/ex.org/blog/bla/", resource.filedir
     end


### PR DESCRIPTION
As Answer to #145 .
Fix #102 properly.

If I understand it correctly this pr addressed the issue, as pointed out in the readme:

> Note: Since Jekyll 3.3.0 there is a special behavior of the jekyll serve command in a development environment. Jekyll overwrites the site.url variable with your host and port reference, as described in the Jekyll documentation. The behavior breaks the jekyll-rdf resource creation. If you want to use jekyll serve you have to set the environment variable JEKYLL_ENV=production.

It might not be a good idea to overwrite the behavior of jekyll for our plug-in in this case. Since there might be side effects, now or in the future.
I would suggest instead to output a warning in the case, that `@site.config["url"] != Jekyll::JekyllRdf::Helper::RdfHelper::config["url"]`.

We should also support a new `jeykll_rdf` config key `baseiri`which would overwrite `@site.config["url"]` and `@site.config["baseurl"]` in any case.