### PR TITLE
index.html shows on empty path

### DIFF
--- a/lib/jekyll/drops/rdf_resource.rb
+++ b/lib/jekyll/drops/rdf_resource.rb
@@ -278,7 +278,7 @@ module Jekyll #:nodoc:
           if(file_name[-2..-1] == "#/")
             file_name = file_name[0..-3]
           end
-          if(file_name[-1] == '/')
+          if(file_name[-1] == '/' || (file_name.eql? ""))
             file_name << "index.html"
           else
             last_slash = file_name.rindex('/')


### PR DESCRIPTION
small fix that stops index.html from being hidden if the domain_url and baseurl make up the entire resource iri
Fix #148 