### PR TITLE
Add support for creating hybrid pages

### DIFF
--- a/lib/jekyll/helper/rdf_generator_helper.rb
+++ b/lib/jekyll/helper/rdf_generator_helper.rb
@@ -123,7 +123,19 @@ module Jekyll
         def create_page(site, resource, mapper, global_config)
           page = RdfPageData.new(site, site.source, resource, mapper, global_config)
           if(page.complete)
-            site.pages << page
+            changes = false
+            site.pages.map!{|old_page|
+              if (File.join(old_page.dir, old_page.name) == File.join(page.dir, page.name))
+                changes||=true
+                page.assimilate_page(old_page)
+                page
+              else
+                old_page
+              end
+            }
+            unless changes
+              site.pages << page
+            end
             resource.add_necessities(site, page)
             resource.subResources.each {|key, value|
               value.add_necessities(site, page)

--- a/lib/jekyll/helper/rdf_page_helper.rb
+++ b/lib/jekyll/helper/rdf_page_helper.rb
@@ -2,6 +2,18 @@ module Jekyll
   module JekyllRdf
     module Helper
       module RdfPageHelper
+
+        def assimilate_page page
+          self.data.merge!(page.data)
+          setData()
+          if self.content.nil?
+            self.content = page.content
+          else
+            self.content.gsub!(/{{\s*content\s*}}/, page.content)
+          end
+          self
+        end
+
         private
         include Jekyll::JekyllRdf::Helper::RdfPrefixHelper
         ##
@@ -32,9 +44,7 @@ module Jekyll
           end
           @path = @site.layouts[@template].path
           self.read_yaml(@site.layouts[@template].instance_variable_get(:@base_dir), @site.layouts[@template].name)
-          self.data['title'] = @resource.iri
-          self.data['rdf'] = @resource
-          self.data['template'] = @template
+          setData()
           if(!@resource.subResources.nil?)
             self.data['sub_rdf'] = @resource.subResources.values
             self.data['sub_rdf'].each { |res|
@@ -42,6 +52,13 @@ module Jekyll
               res.site = site
             }
           end
+        end
+
+        def setData
+          self.data['title'] = @resource.iri
+          self.data['rdf'] = @resource
+          self.data['template'] = @template
+          self.data['layout'] = @site.layouts[@template].data['layout']
         end
 
         ##

--- a/test/source/_config.yml
+++ b/test/source/_config.yml
@@ -62,3 +62,4 @@ jekyll_rdf:
     "http://example.org/B#some" : "test_rdf_get"
     "http://example.org/C" : "test_rdf_get"
     "http://www.ifi.uio.no/INF3580/pages" : "sites_covered"
+    "http://www.ifi.uio.no/INF3580/ex/hybrid/" : "conflictWrap"

--- a/test/source/_layouts/conflictWrap.html
+++ b/test/source/_layouts/conflictWrap.html
@@ -1,0 +1,14 @@
+---
+---
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>TODO supply a title</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <h1>This page is a conflict wrapper for the following page:</h1>
+        {{content}}
+    </body>
+</html>

--- a/test/source/_layouts/merge.html
+++ b/test/source/_layouts/merge.html
@@ -1,0 +1,4 @@
+---
+---
+outer part of a merged page 
+ {{ content }}

--- a/test/source/_layouts/nMerge.html
+++ b/test/source/_layouts/nMerge.html
@@ -1,0 +1,4 @@
+---
+---
+an unmerged page 
+ {{ content }}

--- a/test/source/ex/hybrid.html
+++ b/test/source/ex/hybrid.html
@@ -1,0 +1,3 @@
+---
+---
+<h3>Our Hybrid page</h3>

--- a/test/source/ex/hybrid/index.html
+++ b/test/source/ex/hybrid/index.html
@@ -1,0 +1,3 @@
+---
+---
+<h3>Our Hybrid page</h3>

--- a/test/source/rdf-data/simpsons.ttl
+++ b/test/source/rdf-data/simpsons.ttl
@@ -199,3 +199,4 @@ plha:gem plh:predicate plh:object.
 <http://example.org/date> <http://example.org/dateTimeSec> "2018-06-12T12:42:55+02:00"^^xsd:dateTime .
 
 base:pages a base:page .
+<http://www.ifi.uio.no/INF3580/ex/hybrid/> rdfs:label "Some label".

--- a/test/test_rdf_main_generator.rb
+++ b/test/test_rdf_main_generator.rb
@@ -34,11 +34,15 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
   end
 
   context "create_page from rdf_main_generator" do
-    should "create a page with the right title" do
+    setup do
       @resources_to_templates = {
-        "http://www.ifi.uio.no/INF3580/simpsons#Homer" => "homer",
-        "http://placeholder.host.plh/placeholder#Placeholder" => "Placeholder"
-        }
+        "http://www.ifi.uio.no/INF3580/simpsons/Homer" => "homer",
+        "http://placeholder.host.plh/placeholder#Placeholder" => "Placeholder",
+        "this://should/merge/merge" => "merge",
+        "this://should/also/merge/merge" => "merge",
+        "this://should/not/merge/merge" => "nMerge",
+        "this://should/be/copied/merge/merge" => "nil"
+      }
       @classes_to_templates = {
         "http://xmlns.com/foaf/0.1/Person" => "person",
         "http://pcai042.informatik.uni-leipzig.de/~dtp16#SpecialPerson" => "SpecialPerson",
@@ -46,23 +50,52 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
       }
       @default_template = "default"
       res_helper.global_site = true
-      @resource1 = res_helper.basic_resource("http://www.ifi.uio.no/INF3580/simpsons#Homer")
-      @resource2 = res_helper.basic_resource("http://www.ifi.uio.no/INF3580/simpsons#Maggie")
+      @resource1 = res_helper.basic_resource("http://www.ifi.uio.no/INF3580/simpsons/Homer")
+      @resource2 = res_helper.basic_resource("http://www.ifi.uio.no/INF3580/simpsons/Maggie")
       @resource3 = res_helper.basic_resource("http://resource3")
       res_helper.global_site = false
       @mapper = Jekyll::RdfTemplateMapper.new(@resources_to_templates, @classes_to_templates, @default_template, sparql)
-      config = Jekyll.configuration(TestHelper::TEST_OPTIONS)
-      site = Jekyll::Site.new(config)
-      site.data['resources'] = []
-      site.layouts["homer"] = Jekyll::Layout.new(site, site.source, "homer.html")
-      site.layouts["person"] = Jekyll::Layout.new(site, site.source, "person.html")
-      site.layouts["default"] = Jekyll::Layout.new(site, site.source, "default.html")
-      create_page(site, @resource1, @mapper, config)
-      create_page(site, @resource2, @mapper, config)
-      create_page(site, @resource3, @mapper, config)
-      assert_equal "http://www.ifi.uio.no/INF3580/simpsons#Homer", site.pages[0].data['title']
-      assert_equal "http://www.ifi.uio.no/INF3580/simpsons#Maggie", site.pages[1].data['title']
-      assert_equal "http://resource3", site.pages[2].data['title']
+      @config = Jekyll.configuration(TestHelper::TEST_OPTIONS)
+      @site = Jekyll::Site.new(@config)
+      @site.data['resources'] = []
+      @site.layouts["homer"] = Jekyll::Layout.new(@site, @site.source, "homer.html")
+      @site.layouts["person"] = Jekyll::Layout.new(@site, @site.source, "person.html")
+      @site.layouts["default"] = Jekyll::Layout.new(@site, @site.source, "default.html")
+      @site.layouts["merge"] = Jekyll::Layout.new(@site, File.join(@site.source, "_layouts"), "merge.html")
+      @site.layouts["merge"].content = "outer part of a merged page \n {{ content }}"
+      @site.layouts["nMerge"] = Jekyll::Layout.new(@site, File.join(@site.source, "_layouts"), "nMerge.html")
+      @site.layouts["nMerge"].content = "an unmerged page \n {{ content }}"
+      @site.layouts["nil"] = Jekyll::Layout.new(@site, File.join(@site.source, "_layouts"), "nil")
+      @site.pages = []
+    end
+
+    should "create a page with the right title" do
+      create_page(@site, @resource1, @mapper, @config)
+      create_page(@site, @resource2, @mapper, @config)
+      create_page(@site, @resource3, @mapper, @config)
+      assert_equal "http://www.ifi.uio.no/INF3580/simpsons/Homer", @site.pages[0].data['title']
+      assert_equal "http://resource3", @site.pages[2].data['title']
+    end
+
+    should "assimilate already existing pages if they share the same path" do
+      @site.pages << Jekyll::Page.new(@site, @site.source, "rdfsites/this/should", "merge.html")
+      @site.pages.last.content = "this is the first normal part"
+      @site.pages << Jekyll::Page.new(@site, @site.source, "rdfsites/this/should/also", "merge.html")
+      @site.pages.last.content = "this is the second normal part"
+      @site.pages << Jekyll::Page.new(@site, @site.source, "rdfsites/this/should/wont", "merge.html")
+      @site.pages.last.content = "this is the third normal part"
+      @site.pages << Jekyll::Page.new(@site, @site.source, "rdfsites/this/should/be/copied", "merge.html")
+      @site.pages.last.content = "this should be the only line in this file"
+      create_page(@site, Jekyll::JekyllRdf::Drops::RdfResource.new("this://should/merge/merge"), @mapper, @config)
+      create_page(@site, Jekyll::JekyllRdf::Drops::RdfResource.new("this://should/also/merge/merge"), @mapper, @config)
+      create_page(@site, Jekyll::JekyllRdf::Drops::RdfResource.new("this://should/not/merge/merge"), @mapper, @config)
+      create_page(@site, Jekyll::JekyllRdf::Drops::RdfResource.new("this://should/be/copied/merge/merge"), @mapper, @config)
+      assert (@site.pages.length.eql? 5), "The page count should be 4 it was #{@site.pages.length}"
+      assert (!!(@site.pages[0].content =~ /outer part of a merged page \n this is the first normal part/)), "content should be:>>>>>\nouter part of a merged page \n this is the first normal part\nbut was:>>>>>\n#{@site.pages[0].content}"
+      assert (!!(@site.pages[1].content =~ /outer part of a merged page \n this is the second normal part/)), "content should be:>>>>>\nouter part of a merged page \n this is the second normal part\nbut was:>>>>>\n#{@site.pages[1].content}"
+      assert (!!(@site.pages[2].content =~ /this is the third normal part/)), "content should be:>>>>>\nthis is the third normal part\nbut was:>>>>>\n#{@site.pages[2].content}"
+      assert (!!(@site.pages[4].content =~ /an unmerged page/)), "content should be:>>>>>\nan unmerged page\nbut was:>>>>>\n#{@site.pages[3].content}"
+      assert (!!(@site.pages[3].content =~ /this should be the only line in this file/)), "This page should only contain >>>this should be the only line in this file<<<\ncontained: #{@site.pages[4].content}"
     end
   end
 
@@ -220,6 +253,7 @@ class TestRdfTemplateMapper < Test::Unit::TestCase
       @site.layouts["ontology"] = Jekyll::Layout.new(@site, @site.source, "ontology.html")
       @site.layouts["covered"] = Jekyll::Layout.new(@site, @site.source, "covered.html")
       @site.layouts["test_rdf_get"] = Jekyll::Layout.new(@site, @site.source, "test_rdf_get.html")
+      @site.layouts["conflictWrap"] = Jekyll::Layout.new(@site, @site.source, "conflictWrap.html")
       @site.layouts["sites_covered"] = Jekyll::Layout.new(@site, @site.source, "sites_covered.html")
     end
 


### PR DESCRIPTION
**Possible duplicate of #163 .**

Since merging #138 no content is rendered for hybrid pages.

Hybrid pages are pages for which there is a page in the legacy jekyll structure and a resource in the jekyll-rdf model, which would be rendered to the same url.

Jekyll folders:

- `/ex/hybrid.md`

Model:

    <http://example.org/ex/hybrid> rdfs:label "Some label".

`_config.yml`:

    baseurl: ""
    url: "http://example.org"

Both, `/ex/hybrid.md` and `<http://example.org/ex/hybrid>` are rendered to `/ex/hybrid.html`.
Currently both pages are added to the list of `site.pages`. But effectively `/ex/hybrid.md` is overwritten and only `<http://example.org/ex/hybrid>` is rendered.

In the future both, `/ex/hybrid.md` and `<http://example.org/ex/hybrid>` should result in the same page. The page should have the `{{content}}` of `/ex/hybrid.md` but also be able to access the RDF resource `<http://example.org/ex/hybrid>` under `page.rdf`.

An open point is, which layout should be used in this case?
1. the layout defined by jekyll-rdf for the RDF resource
2. the layout specified in the yaml-frontmatter of `/ex/hybrid.md`

I tend to prefer the yaml-frontmatter because it is more obvious to the user. Maybe there should also be a warning, if a layout is defined in the yaml-frontmatter and in the `instance_template_mappings`.

- [x] manually verified the code
- [ ] re-enact bug on latest develop branch
- [ ] show bug is fixed on this feature branch
- [x] testpage provided