### PR TITLE
added rdf_link tag

### DIFF
--- a/lib/jekyll-rdf.rb
+++ b/lib/jekyll-rdf.rb
@@ -60,6 +60,7 @@ require 'jekyll/filters/rdf_container'
 require 'jekyll/filters/rdf_get'
 require 'jekyll/filters/rdf_message'
 require 'jekyll/filters/rdf_page_to_resource'
+require 'jekyll/tags/rdf_link'
 
 
 Liquid::Template.register_filter(Jekyll::JekyllRdf::Filter)

--- a/lib/jekyll/tags/rdf_link.rb
+++ b/lib/jekyll/tags/rdf_link.rb
@@ -1,0 +1,56 @@
+##
+# MIT License
+#
+# Copyright (c) 2016 Elias Saalmann, Christian Frommert, Simon Jakobi,
+# Arne Jonas Präger, Maxi Bornmann, Georg Hackel, Eric Füg
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+module Jekyll
+
+  module JekyllRdf
+
+    ##
+    # Internal module to hold the tag #rdf_link
+    #
+    module Tag
+      class RdfLink < Liquid::Tag
+        def initialize(tag_name, input, tokens)
+          super
+          @input = input.strip
+        end
+
+        def render(context)
+          resource = context[@input]
+          raise ArgumentError.new("No resource found for the given variable #{@input}.") if resource.nil?
+          site = resource.site
+          site.each_site_file do |item|
+            return item.url if item.relative_path.eql? resource.render_path
+            # This takes care of the case for static files that have a leading /
+            return item.url if "/#{item.relative_path}".eql? resource.render_path
+          end
+          raise ArgumentError.new("No file found for #{resource}.")
+        end
+      end
+
+      Liquid::Template.register_tag('rdf_link', RdfLink)
+    end
+  end
+end

--- a/lib/jekyll/tags/rdf_link.rb
+++ b/lib/jekyll/tags/rdf_link.rb
@@ -32,15 +32,18 @@ module Jekyll
     #
     module Tag
       class RdfLink < Liquid::Tag
+        include Jekyll::JekyllRdf::Filter
         def initialize(tag_name, input, tokens)
           super
           @input = input.strip
         end
 
         def render(context)
-          resource = context[@input]
+          resource = Jekyll::JekyllRdf::Drops::RdfResource.new(@input[1..-2]) if (@input[0].eql?("<") && @input[-1].eql?(">"))
+          resource ||= Jekyll::JekyllRdf::Drops::RdfResource.new(rdf_resolve_prefix(@input)[1..-2]) if @input.include?(':')
+          resource ||= context[@input]
           raise ArgumentError.new("No resource found for the given variable #{@input}.") if resource.nil?
-          site = resource.site
+          site = Jekyll::JekyllRdf::Helper::RdfHelper::site
           site.each_site_file do |item|
             return item.url if item.relative_path.eql? resource.render_path
             # This takes care of the case for static files that have a leading /

--- a/test/cases/linkTag/Gemfile
+++ b/test/cases/linkTag/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+group :jekyll_plugins do
+  gem 'jekyll-rdf', :path => '../../../'
+end

--- a/test/cases/linkTag/_config.yml
+++ b/test/cases/linkTag/_config.yml
@@ -1,0 +1,16 @@
+baseurl: "/instance" # the subpath of your site, e.g. /blog
+url: "http://example.org/" # the base hostname & protocol for your site
+# Build settings
+markdown: kramdown
+plugins:
+- jekyll-rdf
+jekyll_rdf:
+  path: "_data/knowledge-base.ttl"
+  restriction: "SELECT ?resourceUri WHERE {?resourceUri ?p ?o FILTER NOT EXISTS{?resourceUri <http://example.org/instance/faultyPredicate> <http://example.org/instance/faultyObject>}}"
+  default_template: "default"
+  class_template_mappings:
+    "http://xmlns.com/foaf/0.1/Person": "person"
+  instance_template_mappings:
+    "http://example.org/instance/resource": "exampleInstance"
+    "http://example.org/instance/faultyResource1": "missingVariable"
+    "http://example.org/instance/faultyResource2": "missingPage"

--- a/test/cases/linkTag/_data/Prefixes.pref
+++ b/test/cases/linkTag/_data/Prefixes.pref
@@ -1,0 +1,7 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX eg: <http://example.org/instance/>
+PREFIX link: <http://www.linked.org/>
+PREFIX anc: <http://example.org/instance/anchor#>

--- a/test/cases/linkTag/_data/knowledge-base.ttl
+++ b/test/cases/linkTag/_data/knowledge-base.ttl
@@ -1,0 +1,18 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix eg: <http://example.org/instance/> .
+@prefix link: <http://www.linked.org/> .
+@prefix anc: <http://example.org/instance/anchor#> .
+
+eg:resource1 eg:predicate eg:object .
+eg:resource2 eg:predicate eg:object .
+link:links eg:predicate eg:object .
+anc:anchor1 eg:predicate eg:object .
+anc:anchor2 eg:predicate eg:object .
+eg:faultyResource1 eg:faultyPredicate eg:faultyObject .
+eg:faultyResource2 eg:faultyPredicate eg:faultyObject .
+eg:person a foaf:Person .
+eg:person foaf:age "28"^^xsd:int .
+eg:person foaf:name "Jeanne Doe" .

--- a/test/cases/linkTag/_layouts/default.html
+++ b/test/cases/linkTag/_layouts/default.html
@@ -1,0 +1,12 @@
+---
+---
+<!DOCTYPE html>
+  <html>
+    <head></head>
+    <body>
+      <div>
+        <h4>This is made with jekyll-rdf</h4>
+        {{content}}
+      </div>
+    </body>
+  </html>

--- a/test/cases/linkTag/_layouts/exampleInstance.html
+++ b/test/cases/linkTag/_layouts/exampleInstance.html
@@ -1,0 +1,8 @@
+---
+layout: default
+rdf_prefix_path: _data/Prefixes.pref
+---
+<div class="instance">
+  <h6> This page is mapped to: </h6>
+  {{page.rdf}}
+</div>

--- a/test/cases/linkTag/_layouts/missingPage.html
+++ b/test/cases/linkTag/_layouts/missingPage.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<html>
+    <head>
+        <title>TODO supply a title</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <h5>Missing Page</h5>
+        <div>
+            {%- assign myLink = "<http://this/does/not/exist>" | rdf_get -%}
+            {% rdf_link myLink %}
+        </div>
+    </body>
+</html>

--- a/test/cases/linkTag/_layouts/missingVariable.html
+++ b/test/cases/linkTag/_layouts/missingVariable.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<html>
+    <head>
+        <title>Missing Variable</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <h5>Missing Variable</h5>
+        <div> {% rdf_link myLink %}</div>
+    </body>
+</html>

--- a/test/cases/linkTag/_layouts/person.html
+++ b/test/cases/linkTag/_layouts/person.html
@@ -1,0 +1,15 @@
+---
+layout: default
+rdf_prefix_path: _data/Prefixes.pref
+---
+<div class="person">
+  <h6>
+    name:
+  </h6>
+  {{page.rdf | rdf_property: "foaf:name"}}
+  <br/>
+  <h6>
+    age:
+  </h6>
+  {{page.rdf | rdf_property: "foaf:age"}}
+</div>

--- a/test/cases/linkTag/link/link.html
+++ b/test/cases/linkTag/link/link.html
@@ -12,6 +12,8 @@ This should contain a working link:
     {%- assign myLink = "anc:anchor1" | rdf_get -%}
   <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a> <br/>
     {%- assign myLink = "anc:anchor2" | rdf_get -%}
-  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a>
+  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a> <br/>
+  <a href="{{ site.baseurl }}{% rdf_link <http://example.org/instance/resource1> %}">link</a> <br/>
+  <a href="{{ site.baseurl }}{% rdf_link eg:resource2 %}">link</a>
 </div>
 

--- a/test/cases/linkTag/link/link.html
+++ b/test/cases/linkTag/link/link.html
@@ -1,0 +1,17 @@
+---
+rdf_prefix_path: _data/Prefixes.pref
+---
+This should contain a working link:
+<div>
+    {%- assign myLink = "eg:resource1" | rdf_get -%}
+  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a> <br/>
+    {%- assign myLink = "eg:resource2" | rdf_get -%}
+  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a> <br/>
+    {%- assign myLink = "link:links" | rdf_get -%}
+  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a> <br/>
+    {%- assign myLink = "anc:anchor1" | rdf_get -%}
+  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a> <br/>
+    {%- assign myLink = "anc:anchor2" | rdf_get -%}
+  <a href="{{ site.baseurl }}{% rdf_link myLink %}">link</a>
+</div>
+

--- a/test/cases/linkTag/link/linked/linked.html
+++ b/test/cases/linkTag/link/linked/linked.html
@@ -1,0 +1,3 @@
+---
+---
+<h5>This should be linked to</h5>

--- a/test/test_cases.rb
+++ b/test/test_cases.rb
@@ -265,11 +265,13 @@ class TestCases < Test::Unit::TestCase
       content = file[/\<div\>(.|\s)*\<\/div>/][5..-7].strip.split("<br/>").map do |entry|
         entry.strip
       end
-      assert '<a href="/instance/resource1.html">link</a>'.eql?(content[0]), "expected: >7< was: >#{content[0]}<"
+      assert '<a href="/instance/resource1.html">link</a>'.eql?(content[0]), "expected: ><a href=\"/instance/resource1.html\">link</a>< was: >#{content[0]}<"
       assert '<a href="/instance/resource2.html">link</a>'.eql?(content[1]), "expected: ><a href=\"/instance/resource2.html\">link</a>< was: >#{content[1]}<"
       assert '<a href="/instance/rdfsites/http/www.linked.org/links.html">link</a>'.eql?(content[2]), "expected: ><a href=\"/instance/rdfsites/http/www.linked.org/links.html\">link</a>< was: >#{content[2]}<"
       assert '<a href="/instance/anchor.html">link</a>'.eql?(content[3]), "expected: ><a href=\"/instance/anchor.html\">link</a>< was: >#{content[3]}<"
       assert '<a href="/instance/anchor.html">link</a>'.eql?(content[4]), "expected: ><a href=\"/instance/anchor.html\">link</a>< was: >#{content[4]}<"
+      assert '<a href="/instance/resource1.html">link</a>'.eql?(content[5]), "expected: ><a href=\"/instance/resource1.html\">link</a>< was: >#{content[5]}<"
+      assert '<a href="/instance/resource2.html">link</a>'.eql?(content[6]), "expected: ><a href=\"/instance/resource2.html\">link</a>< was: >#{content[6]}<"
     end
 
     should "raise an Argumenterror if the variable in rdf_link is not used" do

--- a/test/test_cases.rb
+++ b/test/test_cases.rb
@@ -253,4 +253,45 @@ class TestCases < Test::Unit::TestCase
       assert_equal "THIS WAS ALL LOWER CASE", content[5]
     end
   end
+
+  context "cases/linkTag" do
+    should "let rdf_link link resources to their rendered page." do
+      @source = File.join(File.dirname(__FILE__), "cases/linkTag")
+      config = Jekyll.configuration(YAML.load_file(File.join(@source, '_config.yml')).merge!({'source' => @source, 'destination' => File.join(@source, "_site")}))
+      site = Jekyll::Site.new(config)
+      site.process
+      content = []
+      file = File.read("#{@source}/_site/link/link.html")
+      content = file[/\<div\>(.|\s)*\<\/div>/][5..-7].strip.split("<br/>").map do |entry|
+        entry.strip
+      end
+      assert '<a href="/instance/resource1.html">link</a>'.eql?(content[0]), "expected: >7< was: >#{content[0]}<"
+      assert '<a href="/instance/resource2.html">link</a>'.eql?(content[1]), "expected: ><a href=\"/instance/resource2.html\">link</a>< was: >#{content[1]}<"
+      assert '<a href="/instance/rdfsites/http/www.linked.org/links.html">link</a>'.eql?(content[2]), "expected: ><a href=\"/instance/rdfsites/http/www.linked.org/links.html\">link</a>< was: >#{content[2]}<"
+      assert '<a href="/instance/anchor.html">link</a>'.eql?(content[3]), "expected: ><a href=\"/instance/anchor.html\">link</a>< was: >#{content[3]}<"
+      assert '<a href="/instance/anchor.html">link</a>'.eql?(content[4]), "expected: ><a href=\"/instance/anchor.html\">link</a>< was: >#{content[4]}<"
+    end
+
+    should "raise an Argumenterror if the variable in rdf_link is not used" do
+      assert_raise(ArgumentError, "No resource found for the given variable.") do
+        TestHelper::setErrOutput
+        @source = File.join(File.dirname(__FILE__), "cases/linkTag")
+        config = Jekyll.configuration(YAML.load_file(File.join(@source, '_config.yml')).merge!({'source' => @source, 'destination' => File.join(@source, "_site")}).merge!({"jekyll_rdf" => {'restriction' => 'SELECT ?resourceUri WHERE {?resourceUri ?p ?o. FILTER (?resourceUri != <http://example.org/instance/faultyResource2>) }'}}))
+        site = Jekyll::Site.new(config)
+        site.process
+        TestHelper::resetErrOutput
+      end
+    end
+
+    should "raise an Argumenterror if the variable in rdf_link refereces a resource whose page was not rendered" do
+      assert_raise(ArgumentError, "No file found for http://this/does/not/exist.") do
+        TestHelper::setErrOutput
+        @source = File.join(File.dirname(__FILE__), "cases/linkTag")
+        config = Jekyll.configuration(YAML.load_file(File.join(@source, '_config.yml')).merge!({'source' => @source, 'destination' => File.join(@source, "_site")}).merge!({"jekyll_rdf" => {'restriction' => 'SELECT ?resourceUri WHERE {?resourceUri ?p ?o. FILTER (?resourceUri != <http://example.org/instance/faultyResource1>) }'}}))
+        site = Jekyll::Site.new(config)
+        site.process
+        TestHelper::resetErrOutput
+      end
+    end
+  end
 end


### PR DESCRIPTION
Close #144.
Close #142.

rdf_link is a replacement for jekylls link tag to support resource linking
use rdf_link in the following manner:

{% assign myLink = <your_resource> | rdf_get %}
{% rdf_link myLink %}