### PR TITLE
Fix version of net-http-persistent to 2.9 because of some windows bug

### DIFF
--- a/jekyll-rdf.gemspec
+++ b/jekyll-rdf.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['lib/**/*.rb']
   s.homepage    = 'https://github.com/white-gecko/jekyll-rdf'
   s.license     = 'MIT'
+  s.add_runtime_dependency 'net-http-persistent',  '~> 2.9'        # https://github.com/white-gecko/jekyll-rdf/issues/197
   s.add_runtime_dependency 'linkeddata',           '~> 2.0'
   s.add_runtime_dependency 'sparql',               '~> 2.2', '>= 2.2.1'
   s.add_runtime_dependency 'jekyll',               '~> 3.1'


### PR DESCRIPTION
Fix version of net-http-persistent to 2.9 because of some windows bug.

https://github.com/drbrain/net-http-persistent/issues/79

Fix #197.