### PR TITLE
preinit @@use_page

### DIFF
--- a/lib/jekyll/helper/rdf_general_helper.rb
+++ b/lib/jekyll/helper/rdf_general_helper.rb
@@ -31,6 +31,7 @@ module Jekyll
       #
       module RdfHelper
         @@prefixes = {}
+        @@usePage = false
 
         def self.sparql= sparql
           @@sparql = sparql


### PR DESCRIPTION
Fix #219 
I'm honestly not sure, if this will solve the problem.
when I tested it, another error was produced (one that seems to be rather a problem with the testproject itself than the plugin).
The issue itself was caused because a prefixresolve was requested before the hook for rendering pages was ever triggered.  Normaly, this should not be possible. So we should examine this problem in a separate issue.